### PR TITLE
update datamodel for dc3

### DIFF
--- a/doc/DESI_SPECTRO_REDUX/PRODNAME/bricks/BRICKNAME/zbest-BRICKNAME.rst
+++ b/doc/DESI_SPECTRO_REDUX/PRODNAME/bricks/BRICKNAME/zbest-BRICKNAME.rst
@@ -5,8 +5,8 @@ zbest-BRICKNAME.fits
 *This is a placeholder for the redshift data model*
 
 This holds the classification and redshift information for targets.
-The formats are TBD, but it should be row-matched to the spectra in
-coadd-BRICKNAME.rst .  This is not yet the case.
+It contains the same TARGETIDs as the input brick-{camera}-{brickname}.fits
+files, but they could be in a different order.
 
 regex: ``zbest-[0-9]{4}[pm][0-9]{3}\.fits``
 
@@ -14,15 +14,11 @@ Nominally the HDUs will be:
 
   - HDU0 (empty)
   - HDU1 (ZBEST) : binary table with best redshift fit results
-  - ...
 
 Inputs
 ======
 
-Written by XXX, using:
-
-  - coadd (coadded spectra)
-  - brick (individual spectra)
+Written by ``desi_zfind.py``, using individual brick-{channel}-{expid}.fits files.
 
 HDU1
 ----

--- a/doc/DESI_SPECTRO_REDUX/PRODNAME/calib2d/NIGHT/fiberflat-CHANNEL-EXPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/PRODNAME/calib2d/NIGHT/fiberflat-CHANNEL-EXPID.rst
@@ -8,16 +8,13 @@ General Description
 Summary
 -------
 
-Fiber flat
+This file contains the fiberflat such that newflux = rawflux/fiberflat.
 
 Naming Convention
 -----------------
 
-*TODO*
-
-``fiberflat-b0-00000001.fits``, where ...
-*Give a human readable description of the filename, e.g.
-``blat-{EXPID}`` where ``{EXPID}`` is the 8-digit exposure ID.*
+``fiberflat-{camera}-{expid}.fits``, where ``{camera}`` is the camera
+name (e.g. b0, r1, z9) and ``{expid}`` is the zero padded 8-digit exposure ID.
 
 regex: ``fiberflat-[brz][0-9]-[0-9]{8}\.fits``
 
@@ -39,35 +36,193 @@ HDU3_  MEANSPEC   IMAGE average spectrum[nwave]
 HDU4_  WAVELENGTH IMAGE wavelength grid[nwave] in Angstroms
 ====== ========== ===== ===================
 
+Current pipeline (as of 2016-06-16) writes HDU0 with EXTNAME=FLUX, having
+inherited that from the input frame.  That should be changed to FIBERFLAT
+(as described above) or no HDU 0 EXTNAME (formal FITS standard).
+
+astropy currently writes this as FITS file which it can read but cfitsio
+cannot.  It is unknown which library is at fault.
 
 FITS Header Units
 =================
 
-*TODO: Describe in detail*
-
-*These empty headers are needed to avoid sphinx build errors*
-
 HDU0
 ----
 
-*TODO*
+Mean fiberflat.
+
+Required Header Keywords
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Header keywords are inherited from the input Frame file.
+
+======== ====================================================================================================== ===== ==============================================
+KEY      Example Value                                                                                          Type  Comment
+======== ====================================================================================================== ===== ==============================================
+NAXIS1   2975                                                                                                   int
+NAXIS2   500                                                                                                    int
+EXTNAME  FLUX                                                                                                   str   name of this binary table extension
+TELRA    335.03                                                                                                 float Telescope pointing RA [degrees]
+EXPID    0                                                                                                      int   DESI exposure ID
+TILEID   4                                                                                                      int   DESI tile ID
+TELDEC   19.88                                                                                                  float Telescope pointing dec [degrees]
+DATE-OBS 2016-07-26T22:00:00                                                                                    str   Start of exposure
+FLAVOR   flat                                                                                                   str   Flavor [arc, flat, science, ...]
+NIGHT    20160726                                                                                               str   Night of observation YEARMMDD
+AIRMASS  1.0                                                                                                    float Airmass at middle of exposure
+EXPTIME  10                                                                                                     int   Exposure time [sec]
+CAMERA   z0                                                                                                     str
+GAIN1    1.0                                                                                                    float
+GAIN2    1.0                                                                                                    float
+GAIN3    1.0                                                                                                    float
+GAIN4    1.0                                                                                                    float
+RDNOISE1 2.9                                                                                                    float
+RDNOISE2 2.9                                                                                                    float
+RDNOISE3 2.9                                                                                                    float
+RDNOISE4 2.9                                                                                                    float
+PRESEC1  [1:7,1:2064]                                                                                           str
+DATASEC1 [8:2064,1:2064]                                                                                        str
+BIASSEC1 [2065:2114,1:2064]                                                                                     str
+CCDSEC1  [1:2057,1:2064]                                                                                        str
+PRESEC2  [4222:4228,1:2064]                                                                                     str
+DATASEC2 [2165:4221,1:2064]                                                                                     str
+BIASSEC2 [2115:2164,1:2064]                                                                                     str
+CCDSEC2  [2058:4114,1:2064]                                                                                     str
+PRESEC3  [1:7,2065:4128]                                                                                        str
+DATASEC3 [8:2064,2065:4128]                                                                                     str
+BIASSEC3 [2065:2114,2065:4128]                                                                                  str
+CCDSEC3  [1:2057,2065:4128]                                                                                     str
+PRESEC4  [4222:4228,2065:4128]                                                                                  str
+DATASEC4 [2165:4221,2065:4128]                                                                                  str
+BIASSEC4 [2115:2164,2065:4128]                                                                                  str
+CCDSEC4  [2058:4114,2065:4128]                                                                                  str
+OVERSCN1 186.790687984                                                                                          float
+OBSRDN1  2.91374495497                                                                                          float
+OVERSCN2 142.624612403                                                                                          float
+OBSRDN2  2.91379123644                                                                                          float
+OVERSCN3 150.976618217                                                                                          float
+OBSRDN3  2.90516702412                                                                                          float
+OVERSCN4 166.076046512                                                                                          float
+OBSRDN4  2.92814520174                                                                                          float
+INHERIT  T                                                                                                      bool
+CHECKSUM a6Zgc4Zga4Zga4Zg                                                                                       str   HDU checksum updated 2016-06-10T22:02:54
+DATASUM  4180184824                                                                                             str   data unit checksum updated 2016-06-10T22:02:54
+NSPEC    5                                                                                                      int   Number of spectra
+WAVEMIN  7445.0                                                                                                 float First wavelength [Angstroms]
+WAVEMAX  9824.0                                                                                                 float Last wavelength [Angstroms]
+WAVESTEP 0.8                                                                                                    float Wavelength step size [Angstroms]
+SPECTER  0.5.0dev1                                                                                              str   https://github.com/desihub/specter
+IN_PSF   ...st/calib2d/psf/20160726/psfnight-z0.fits                                                            str   Input spectral PSF
+IN_IMG   .../dailytest/20160726/pix-z0-00000000.fits                                                            str   Input image
+FIBERMIN 0                                                                                                      int
+DEPNAM00 python                                                                                                 str
+DEPVER00 2.7.11 |Anaconda 2.0.1 (x86_64)| (default, Dec  6 2015, 18:57:58)  [GCC 4.2.1 (Apple Inc. build 5577)] str
+DEPNAM01 numpy                                                                                                  str
+DEPVER01 1.10.4                                                                                                 str
+DEPNAM02 scipy                                                                                                  str
+DEPVER02 0.17.0                                                                                                 str
+DEPNAM03 astropy                                                                                                str
+DEPVER03 1.1.1                                                                                                  str
+DEPNAM04 yaml                                                                                                   str
+DEPVER04 3.11                                                                                                   str
+DEPNAM05 matplotlib                                                                                             str
+DEPVER05 1.5.0                                                                                                  str
+DEPNAM06 desiutil                                                                                               str
+DEPVER06 1.5.0.dev325                                                                                           str
+DEPNAM07 desispec                                                                                               str
+DEPVER07 0.5.0.dev858                                                                                           str
+DEPNAM08 specter                                                                                                str
+DEPVER08 0.5.0dev1                                                                                              str
+DEPNAM09 speclite                                                                                               str
+DEPVER09 0.3dev271.dev351                                                                                       str
+======== ====================================================================================================== ===== ==============================================
+
+Data: FITS image [float32, 2975x500]
 
 HDU1
 ----
 
-*TODO*
+EXTNAME = IVAR
+
+Inverse variance of the fiberflat.
+
+Required Header Keywords
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+======== ================ ==== ==============================================
+KEY      Example Value    Type Comment
+======== ================ ==== ==============================================
+NAXIS1   2975             int
+NAXIS2   500              int
+EXTNAME  IVAR             str  extension name
+CHECKSUM 9PBADOB69OBAAOB3 str  HDU checksum updated 2016-06-10T22:02:54
+DATASUM  3462666130       str  data unit checksum updated 2016-06-10T22:02:54
+======== ================ ==== ==============================================
+
+Data: FITS image [float32, 2975x500]
 
 HDU2
 ----
 
-*TODO*
+EXTNAME = MASK
+
+Mask of the fiberflat; 0=good.
+
+Required Header Keywords
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+======== ================ ==== ==============================================
+KEY      Example Value    Type Comment
+======== ================ ==== ==============================================
+NAXIS1   2975             int  length of original image axis
+NAXIS2   500              int  length of original image axis
+BSCALE   1                int
+BZERO    2147483648       int
+EXTNAME  MASK             str  name of this binary table extension
+CHECKSUM FcV3FZT2FbT2FZT2 str  HDU checksum updated 2016-06-10T22:02:54
+DATASUM  743774           str  data unit checksum updated 2016-06-10T22:02:54
+======== ================ ==== ==============================================
+
+Data: FITS image [int32, 2975x500]
 
 HDU3
 ----
 
-*TODO*
+EXTNAME = MEANSPEC
+
+*Summarize the contents of this HDU.*
+
+Required Header Keywords
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+======== ================ ==== ==============================================
+KEY      Example Value    Type Comment
+======== ================ ==== ==============================================
+NAXIS1   2975             int
+EXTNAME  MEANSPEC         str  extension name
+CHECKSUM cBAJf94GcAAGc93G str  HDU checksum updated 2016-06-10T22:02:54
+DATASUM  2259023115       str  data unit checksum updated 2016-06-10T22:02:54
+======== ================ ==== ==============================================
+
+Data: FITS image [float32, 2975]
 
 HDU4
 ----
 
-*TODO*
+EXTNAME = WAVELENGTH
+
+Wavelength grid in Angstroms used by this fiberflat.
+
+Required Header Keywords
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+======== ================ ==== ==============================================
+KEY      Example Value    Type Comment
+======== ================ ==== ==============================================
+NAXIS1   2975             int
+EXTNAME  WAVELENGTH       str  extension name
+CHECKSUM 9mXPJkUO9kUOGkUO str  HDU checksum updated 2016-06-10T22:02:54
+DATASUM  3037649504       str  data unit checksum updated 2016-06-10T22:02:54
+======== ================ ==== ==============================================
+
+Data: FITS image [float32, 2975]

--- a/doc/DESI_SPECTRO_REDUX/PRODNAME/calib2d/psf/NIGHT/psfboot-CAMERA.rst
+++ b/doc/DESI_SPECTRO_REDUX/PRODNAME/calib2d/psf/NIGHT/psfboot-CAMERA.rst
@@ -8,16 +8,20 @@ psfboot-CAMERA
 :Regex: ``psfboot-[brz][0-9]\.fits``
 :File Type: FITS, 64 KB
 
+This file is a first fit to the x vs. y vs. wavelength solutions and
+the mean Gaussian sigma wavelength dispersion per fiber.  It is used as
+a starting point for more refined fits.
+
 Contents
 ========
 
-====== ======= ===== ===================
+====== ======= ===== ==========================================
 Number EXTNAME Type  Contents
-====== ======= ===== ===================
-HDU0_          IMAGE *Brief Description*
-HDU1_          IMAGE *Brief Description*
-HDU2_          IMAGE *Brief Description*
-====== ======= ===== ===================
+====== ======= ===== ==========================================
+HDU0_          IMAGE Legendre coefficients for x vs. wavelength
+HDU1_          IMAGE Legendre coefficients for y vs. wavelength
+HDU2_          IMAGE Gaussian sigma per fiber
+====== ======= ===== ==========================================
 
 
 FITS Header Units
@@ -26,54 +30,61 @@ FITS Header Units
 HDU0
 ----
 
-*Summarize the contents of this HDU.*
+Legendre coefficients for x vs. wavelength.  Header keywords
+WAVEMIN and WAVEMAX provide the mapping from wavelength to the
+[-1,1] domain used for the Legenre polynomials.  i.e. starting
+with wavelength w::
+
+    wx = 2.0*(w-WAVEMIN)/(WAVEMAX-WAVEMIN) - 1.0  #- Map to [-1,1]
+    x[i] = Sum_j XCOEFF[i,j] L_j(wx)              #- evaluate Legendre series
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-======= ============= ===== =======
+======= ============= ===== ===============================
 KEY     Example Value Type  Comment
-======= ============= ===== =======
-NAXIS1  6             int
-NAXIS2  500           int
-WAVEMIN 5563.41034186 float
+======= ============= ===== ===============================
+NAXIS1  6             int   Number of Legendre coefficients
+NAXIS2  500           int   Number of spectra
+WAVEMIN 5563.41034186 float 
 WAVEMAX 7807.04444877 float
-======= ============= ===== =======
+======= ============= ===== ===============================
 
 Data: FITS image [float64, 6x500]
 
 HDU1
 ----
 
-*Summarize the contents of this HDU.*
+Legendre coefficients for y vs. wavelength; see the HDU0 description
+for how to interpret these.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-======= ============= ===== =======
+======= ============= ===== ===============================
 KEY     Example Value Type  Comment
-======= ============= ===== =======
-NAXIS1  6             int
-NAXIS2  500           int
+======= ============= ===== ===============================
+NAXIS1  6             int   Number of Legendre coefficients
+NAXIS2  500           int   Number of spectra
 WAVEMIN 5563.41034186 float
 WAVEMAX 7807.04444877 float
-======= ============= ===== =======
+======= ============= ===== ===============================
 
 Data: FITS image [float64, 6x500]
 
 HDU2
 ----
 
-*Summarize the contents of this HDU.*
+Mean Gaussian sigma wavelength dispersion per fiber.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-====== ============= ==== =======
+====== ============= ==== =================================================
 KEY    Example Value Type Comment
-====== ============= ==== =======
-NAXIS1 500           int
-====== ============= ==== =======
+====== ============= ==== =================================================
+NAXIS1 500           int  Mean wavelength dispersion per fiber in Angstroms
+====== ============= ==== =================================================
 
 Data: FITS image [float64, 500]
 

--- a/doc/DESI_SPECTRO_REDUX/PRODNAME/exposures/NIGHT/EXPID/calib-CAMERA-EXPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/PRODNAME/exposures/NIGHT/EXPID/calib-CAMERA-EXPID.rst
@@ -15,5 +15,8 @@ Nominally the HDUs will be:
   - HDU1 (IVAR) : inverse variance[nspec, nwave] of fluxcalib
   - HDU2 (MASK) : mask[nspec, nwave] of fluxcalib (0=good)
   - HDU3 (WAVELENGTH) : wavelength[nwave] in Angstroms
-  - HDU4 (METADATA) : binary table with one row per standard star giving
-    the details of which model was used, etc.  Details TBD.
+
+We may add an additional HDU with EXTNAME=METADATA containing a
+binary table with one row per standard star giving
+the details of which model was used, etc.
+This is not yet implemented and details TBD.

--- a/doc/DESI_SPECTRO_REDUX/PRODNAME/exposures/NIGHT/EXPID/cframe-CAMERA-EXPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/PRODNAME/exposures/NIGHT/EXPID/cframe-CAMERA-EXPID.rst
@@ -9,6 +9,7 @@ regex: ``cframe-[brz][0-9]-[0-9]{8}\.fits``
 
   - HDU0 (FLUX) : flux[nspec, nwave] - erg/s/cm2/A
   - HDU1 (IVAR) : ivar[nspec, nwave] - (erg/s/cm2/A)^-2
-  - HDU2 (WAVELENGTH) : wavelength[nwave] in Angstroms
-  - HDU3 (RESOLUTION) : R[nspec, ndiag, nwave] - Resolution Matrix
-  - HDU4 (MASK) : mask[nspec, nwave] - 0 is good *MISSING FROM CURRENT FILES*
+  - HDU2 (MASK) : mask[nspec, nwave] - 0=good
+  - HDU3 (WAVELENGTH) : wavelength[nwave] in Angstroms
+  - HDU4 (RESOLUTION) : R[nspec, ndiag, nwave] - Resolution Matrix
+  - HDU5 (FIBERMAP) : Propagated from input DESI_SPECTRO_DATA/NIGHT/fibermap-EXPID.fits

--- a/doc/DESI_SPECTRO_REDUX/PRODNAME/exposures/NIGHT/EXPID/frame-CAMERA-EXPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/PRODNAME/exposures/NIGHT/EXPID/frame-CAMERA-EXPID.rst
@@ -29,14 +29,16 @@ FITS, *TBD* MB
 Contents
 ========
 
-====== ========== ===== ===================
-Number EXTNAME    Type  Contents
-====== ========== ===== ===================
-HDU0_             IMAGE Extracted electrons (photons)
-HDU1_  IVAR       IMAGE Inverse variance of extracted electrons
-HDU2_  WAVELENGTH IMAGE Wavelength grid of the extraction
-HDU3_  RESOLUTION IMAGE Resolution matrix
-====== ========== ===== ===================
+====== ========== ======== ===================
+Number EXTNAME    Type     Contents
+====== ========== ======== ===================
+HDU0_  FLUX       IMAGE    Extracted electrons (photons)
+HDU1_  IVAR       IMAGE    Inverse variance of extracted electrons
+HDU2_  MASK       IMAGE    Bad value mask; 0=good
+HDU3_  WAVELENGTH IMAGE    Wavelength grid of the extraction
+HDU3_  RESOLUTION IMAGE    Resolution matrix
+HDU5_  FIBERMAP   BINTABLE Fibermap
+====== ========== ======== ===================
 
 FITS Header Units
 =================
@@ -99,6 +101,30 @@ Data: FITS image [float64]
 HDU2
 ----
 
+EXTNAME = MASK
+
+*Summarize the contents of this HDU.*
+
+Required Header Keywords
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+======== ================ ==== ==============================================
+KEY      Example Value    Type Comment
+======== ================ ==== ==============================================
+NAXIS1   2951             int  length of original image axis
+NAXIS2   500              int  length of original image axis
+BSCALE   1                int
+BZERO    2147483648       int
+EXTNAME  MASK             str  name of this binary table extension
+CHECKSUM gaU7iZS4gaS4gWS4 str  HDU checksum updated 2016-06-10T16:57:58
+DATASUM  737750           str  data unit checksum updated 2016-06-10T16:57:58
+======== ================ ==== ==============================================
+
+Data: FITS image [int32, 2951x500]
+
+HDU3
+----
+
 EXTNAME = WAVELENGTH
 
 1D array of wavelengths.  NAXIS1 here is the same length as NAXIS2 of
@@ -116,7 +142,7 @@ EXTNAME WAVELENGTH    str
 
 Data: FITS image [float64]
 
-HDU3
+HDU4
 ----
 
 EXTNAME = RESOLUTION
@@ -161,6 +187,14 @@ EXTNAME RESOLUTION    str
 ======= ============= ==== =====================
 
 Data: FITS image [float64]
+
+HDU5
+----
+
+EXTNAME = FIBERMAP
+
+Fibermap propagated from the raw data inputs; see
+DESI_SPECTRO_DATA/NIGHT/fibermap-EXPID.rst.
 
 Notes and Examples
 ==================

--- a/doc/DESI_SPECTRO_REDUX/PRODNAME/exposures/NIGHT/EXPID/sky-CAMERA-EXPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/PRODNAME/exposures/NIGHT/EXPID/sky-CAMERA-EXPID.rst
@@ -4,15 +4,12 @@ sky-CAMERA-EXPID.fits
 
 *This is a placeholder*
 
-
 regex: ``sky-[brz][0-9]-[0-9]{8}\.fits``
 
 This holds the sky model for a given camera and exposure.
 Nominally the HDUs will be:
 
-  - HDU0 (PHOT) : phot[nspec, nwave] - photons/bin
+  - HDU0 (SKY) : phot[nspec, nwave] - photons/bin
   - HDU1 (IVAR) : ivar[nspec, nwave] - (photons/bin)^-2
-
-The wavelength array will be defined by header keywords CRVAL1 and CDELT1
-
-wave = CRVAL1 + np.arange(NAXIS1) * CDELT1
+  - HDU2 (MASK) : mask[nspec, nwave] - 0=good
+  - HDU3 (WAVELENGTH) : wave[nwave]  - wavelength in Angstroms

--- a/doc/DESI_SPECTRO_REDUX/PRODNAME/exposures/NIGHT/EXPID/stdstars-CAMERA-EXPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/PRODNAME/exposures/NIGHT/EXPID/stdstars-CAMERA-EXPID.rst
@@ -7,13 +7,17 @@ stdstars
 This file contains the normalized standard star models fitted to the
 frame data.
 
-Naming convention: stdstars-sp{SPECTROGRAPH}-{EXPID}.fits
+Naming convention: stdstars-{SPECTROGRAPH}-{EXPID}.fits wher
+{SPECTROGRAPH} is the single-digit spectrograph number 0-9, and
+{EXPID} is the zero-padded 8-digit exposure number.
 
-regex: ``stdstars-[brz][0-9]-[0-9]{8}\.fits``
+regex: ``stdstars-[0-9]-[0-9]{8}\.fits``
 
 HDUS:
 
   - HDU0 FLUX : stdstar flux[nstd, nwave] in erg/s/cm^2/Angstrom
-  - HDU1 WAVE : wavelength grid used (SHOULD BE 'WAVELENGTH' INSTEAD?)
-  - HDU2 FIBERS : 1D array of which fibers were used (?!?)
+  - HDU1 WAVELENGTH : wavelength grid used, Angstroms
+  - HDU2 FIBERS : 1D array of which fibers these models correspond to
   - HDU3 METADATA : metadata from input standard star templates
+
+Note: dc3 productions used "WAVE" instead of "WAVELENGTH" for HDU 1.

--- a/doc/DESI_SPECTRO_REDUX/PRODNAME/versions.json.rst
+++ b/doc/DESI_SPECTRO_REDUX/PRODNAME/versions.json.rst
@@ -17,3 +17,7 @@ this production, *e.g.* ::
     "harp": "0.9.8",
     "desispec": "2.3.4"
   }
+  
+Note: the pipeline currently does not write this file.  The code versions
+used are included in the header keywords of the data files, and the commands
+to configure that environment are kept in the ``setup.sh`` file instead.


### PR DESCRIPTION
This PR fixes desihub/desispec#18 to review and update the datamodel based upon the dc3 run.  Some of the documentation files are not yet in the standard form, but at least they informally list the HDUs with descriptions that a human can read, even if our data model consistency checker can't.

I did not check float32 vs. float64 and all header keywords, but I tried to make sure that all HDUs were described and all table columns were listed.