### PR TITLE
Adds DR4 target catalog format

### DIFF
--- a/doc/DESI_TARGET/index.rst
+++ b/doc/DESI_TARGET/index.rst
@@ -14,3 +14,4 @@ with the canonical location of ``$DESI_ROOT/target``
    stdstar-{version}.fits : standard star catalog <stdstar>
    sky-{version}.fits : sky positions catalog <sky>
    fiberassign/index
+   deprecated: DR3 target catalog format <targets-dr3>

--- a/doc/DESI_TARGET/targets-dr3.rst
+++ b/doc/DESI_TARGET/targets-dr3.rst
@@ -98,6 +98,6 @@ In general, the above format contains:
 * Columns needed by fiber assignment (e.g. RA, DEC)
 * Columns needed for traceability (e.g. BRICKNAME, TARGETID, DESI_TARGET, BGS_TARGET, MWS_TARGET)
 
-TARGETID, DESI_TARGET, BGS_TARGET and MWS_TARGET are created by target selection; the rest are pass through from the original input tractor files
+TARGETID, DESI_TARGET, BGS_TARGET and MWS_TARGET are created by target selection; the rest are passed through from the original input tractor files
 
 See http://legacysurvey.org for more details about the columns from input tractor files

--- a/doc/DESI_TARGET/targets-dr3.rst
+++ b/doc/DESI_TARGET/targets-dr3.rst
@@ -1,0 +1,103 @@
+===============
+targets-\*.fits
+===============
+
+General Description
+===================
+
+Summary
+-------
+
+DESI target selection files contain a single binary table covering the
+entire footprint.  They contain the variables used by target selection
+(*e.g.* fluxes), variables needed by fiber assignment (*e.g.* RA, DEC),
+and variables needed for traceability (*e.g.* TARGETFLAG, TARGETID).
+
+Naming Convention
+-----------------
+
+TBD, let's try ``targets-{source}-{version}.fits`` where ``source`` is where the
+input data came from (*e.g.* 'dr1', 'dr2') and ``version`` is the code version
+that wrote this, preferably a git tag of desitargets.
+
+regex: ``targets-dr[0-9]+-v?[0-9]+\.[0-9]+(\.[0-9]+|)\.fits``
+
+Contents
+========
+
+====== ======= ======== ===================
+Number EXTNAME Type     Contents
+====== ======= ======== ===================
+HDU0_          IMAGE    Blank
+HDU1_  TARGETS BINTABLE Target selection table
+====== ======= ======== ===================
+
+
+FITS Header Units
+=================
+
+HDU0
+----
+
+Empty header.
+
+HDU1
+----
+
+Targets.
+
+Required Header Keywords
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+======== ======================================================== ==== ===================================
+KEY      Example Value                                            Type Comment
+======== ======================================================== ==== ===================================
+EXTNAME  TARGETS                                                  str  name of this binary table extension
+DEPNAM00 desitarget                                               str
+DEPVER00 0.1.0                                                    str  desitarget.__version__
+DEPNAM01 desitarget-git                                           str
+DEPVAL01 0.1.0                                                    str  git revision
+DEPNAM02 tractor-files                                            str
+DEPVER02 /project/projectdirs/cosmo/data/legacysurvey/dr1/tractor str  input directory
+======== ======================================================== ==== ===================================
+
+Required Data Table Columns
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+===================== ========== ===== ===================
+Name                  Type       Units Description
+===================== ========== ===== ===================
+BRICKID               int32            Brick ID from tractor input
+BRICKNAME             char[8]          Brick name from tractor input
+BRICK_OBJID           int32            OBJID (unique to brick, but not to file)
+BRICK_PRIMARY         logical          should always be True
+TYPE                  char[4]          tractor object type
+RA                    float64          Right ascension [degrees]
+RA_IVAR               float32          Inverse variance of RA
+DEC                   float64          Declination [degrees]
+DEC_IVAR              float32          Inverse variance of DEC
+DECAM_FLUX            float32[6]       DECam flux from tractor input (ugrizY)
+DECAM_MW_TRANSMISSION float32[6]       Milky Way dust transmission ([0-1] ugrizY)
+WISE_FLUX             float32[4]       WISE flux (W1, W2, W3, W4)
+WISE_MW_TRANSMISSION  float32[4]       Milky Way transmission
+SHAPEEXP_R            float32          Half-light radius of exponential model (>0)
+SHAPEDEV_R            float32          Half-light radius of deVaucouleurs model (>0)
+TARGETID              int64            ID (unique to file and the whole survey)
+DESI_TARGET           int64            DESI (dark time program) target selection bitmask
+BGS_TARGET            int64            BGS (bright time program) target selection bitmask
+MWS_TARGET            int64            MWS (bright time program) target selection bitmask
+===================== ========== ===== ===================
+
+
+Notes and Examples
+==================
+
+In general, the above format contains:
+
+* Columns that were used by target selection (e.g. DECAM_FLUX)
+* Columns needed by fiber assignment (e.g. RA, DEC)
+* Columns needed for traceability (e.g. BRICKNAME, TARGETID, DESI_TARGET, BGS_TARGET, MWS_TARGET)
+
+TARGETID, DESI_TARGET, BGS_TARGET and MWS_TARGET are created by target selection; the rest are pass through from the original input tractor files
+
+See http://legacysurvey.org for more details about the columns from input tractor files

--- a/doc/DESI_TARGET/targets.rst
+++ b/doc/DESI_TARGET/targets.rst
@@ -1,36 +1,29 @@
-===============
-targets-\*.fits
-===============
-
-General Description
+===================
+targets-DRX-VERSION
 ===================
 
-Summary
--------
+:Summary: DESI target selection files contain a single binary table covering the
+    entire footprint.  They contain the variables used by target selection
+    (*e.g.* fluxes), variables needed by fiber assignment (*e.g.* RA, DEC),
+    and variables needed for traceability (*e.g.* TARGETFLAG, TARGETID).
+:Naming Convention: ``targets-DRX-VERSION.fits``, where ``DRX`` is the
+    imaging surveys data release name (e.g. dr4) and ``VERSION`` is the
+    desitarget code version defining the cuts.
+:Regex: ``targets-dr[0-9]+-v?[0-9]+\.[0-9]+(\.[0-9]+|)\.fits``
+:File Type: FITS, 3 GB
 
-DESI target selection files contain a single binary table covering the
-entire footprint.  They contain the variables used by target selection
-(*e.g.* fluxes), variables needed by fiber assignment (*e.g.* RA, DEC),
-and variables needed for traceability (*e.g.* TARGETFLAG, TARGETID).
-
-Naming Convention
------------------
-
-TBD, let's try ``targets-{source}-{version}.fits`` where ``source`` is where the
-input data came from (*e.g.* 'dr1', 'dr2') and ``version`` is the code version
-that wrote this, preferably a git tag of desitargets.
-
-regex: ``targets-dr[0-9]+-v?[0-9]+\.[0-9]+(\.[0-9]+|)\.fits``
+**Note**: this documents the target catalog format starting with DR4 /
+desitarget 0.14.0 .  The previous format is documented in :doc:`targets-dr3`.
 
 Contents
 ========
 
-====== ======= ======== ===================
+====== ======= ======== ============
 Number EXTNAME Type     Contents
-====== ======= ======== ===================
-HDU0_          IMAGE    Blank
-HDU1_  TARGETS BINTABLE Target selection table
-====== ======= ======== ===================
+====== ======= ======== ============
+HDU0_          IMAGE    Empty
+HDU1_  TARGETS BINTABLE Target table
+====== ======= ======== ============
 
 
 FITS Header Units
@@ -39,54 +32,102 @@ FITS Header Units
 HDU0
 ----
 
-Empty header.
+Empty HDU.
 
 HDU1
 ----
 
-Targets.
+EXTNAME = TARGETS
+
+Target selection table
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-======== ======================================================== ==== ===================================
-KEY      Example Value                                            Type Comment
-======== ======================================================== ==== ===================================
-EXTNAME  TARGETS                                                  str  name of this binary table extension
-DEPNAM00 desitarget                                               str
-DEPVER00 0.1.0                                                    str  desitarget.__version__
-DEPNAM01 desitarget-git                                           str
-DEPVAL01 0.1.0                                                    str  git revision
-DEPNAM02 tractor-files                                            str
-DEPVER02 /project/projectdirs/cosmo/data/legacysurvey/dr1/tractor str  input directory
-======== ======================================================== ==== ===================================
+======== ==================== ==== ===================================
+KEY      Example Value        Type Comment
+======== ==================== ==== ===================================
+NAXIS1   243                  int  width of table in bytes
+NAXIS2   15050911             int  number of rows in table
+EXTNAME  TARGETS              str  name of this binary table extension
+DEPNAM00 desitarget           str
+DEPVER00 0.14.0               str
+DEPNAM01 desitarget-git       str
+DEPVER01 unknown              str
+DEPNAM02 sandboxcuts          str
+DEPVER02 F                    bool sandbox cuts were used or not (T/F)
+DEPNAM03 photcat              str
+DEPVER03 dr4                  str
+DEPNAM04 tractor-files        str
+DEPVER04 /data/dr4/sweep/4.0/ str  Full path to input catalogs
+DEPNAM05 qso-selection        str
+DEPVER05 randomforest         str  QSO selection algorithm
+DEPNAM06 HPXNSIDE             str
+DEPVER06 64                   int
+DEPNAM07 HPXNEST              str
+DEPVER07 T                    bool
+======== ==================== ==== ===================================
+
+TODO: HPXNSIDE and HPXNEST should be regular keywords, not DEP* keywords.
 
 Required Data Table Columns
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-===================== ========== ===== ===================
-Name                  Type       Units Description
-===================== ========== ===== ===================
-BRICKID               int32            Brick ID from tractor input
-BRICKNAME             char[8]          Brick name from tractor input
-BRICK_OBJID           int32            OBJID (unique to brick, but not to file)
-BRICK_PRIMARY         logical          should always be True
-TYPE                  char[4]          tractor object type
-RA                    float64          Right ascension [degrees]
-RA_IVAR               float32          Inverse variance of RA
-DEC                   float64          Declination [degrees]
-DEC_IVAR              float32          Inverse variance of DEC
-DECAM_FLUX            float32[6]       DECam flux from tractor input (ugrizY)
-DECAM_MW_TRANSMISSION float32[6]       Milky Way dust transmission ([0-1] ugrizY)
-WISE_FLUX             float32[4]       WISE flux (W1, W2, W3, W4)
-WISE_MW_TRANSMISSION  float32[4]       Milky Way transmission
-SHAPEEXP_R            float32          Half-light radius of exponential model (>0)
-SHAPEDEV_R            float32          Half-light radius of deVaucouleurs model (>0)
-TARGETID              int64            ID (unique to file and the whole survey)
-DESI_TARGET           int64            DESI (dark time program) target selection bitmask
-BGS_TARGET            int64            BGS (bright time program) target selection bitmask
-MWS_TARGET            int64            MWS (bright time program) target selection bitmask
-===================== ========== ===== ===================
+================== ========== =============== ==================================
+Name               Type       Units           Description
+================== ========== =============== ==================================
+RELEASE            int32                      label for column  1
+BRICKID            int32                      Integer brick ID
+BRICKNAME          char[8]                    String brick name
+BRICK_OBJID        int32                      ObjectID on that brick
+TYPE               char[4]                    PSF, SIMP, DEV, EXP
+RA                 float64    deg             Right Ascension      
+DEC                float64    deg             Declination
+RA_IVAR            float32    1/deg2          Inverse variance of RA     
+DEC_IVAR           float32    1/deg2          Inverse variance of dec     
+DCHISQ             float32[5]                 
+FLUX_G             float32    nanomaggies     g-band flux
+FLUX_R             float32    nanomaggies     r-band flux      
+FLUX_Z             float32    nanomaggies     z-band flux
+FLUX_W1            float32    nanomaggies     WISE W1-band flux
+FLUX_W2            float32    nanomaggies     WISE W2-band flux
+FLUX_W3            float32    nanomaggies     WISE W3-band flux
+FLUX_W4            float32    nanomaggies     WISE W4-band flux
+FLUX_IVAR_G        float32    1/nanomaggies2  inverse variance of FLUX_G
+FLUX_IVAR_R        float32    1/nanomaggies2  inverse variance of FLUX_R
+FLUX_IVAR_Z        float32    1/nanomaggies2  inverse variance of FLUX_Z
+FLUX_IVAR_W1       float32    1/nanomaggies2  inverse variance of FLUX_W1
+FLUX_IVAR_W2       float32    1/nanomaggies2  inverse variance of FLUX_W2
+FLUX_IVAR_W3       float32    1/nanomaggies2  inverse variance of FLUX_W3
+FLUX_IVAR_W4       float32    1/nanomaggies2  inverse variance of FLUX_W4
+MW_TRANSMISSION_G  float32                    Milky Way transmission in g
+MW_TRANSMISSION_R  float32          
+MW_TRANSMISSION_Z  float32          
+MW_TRANSMISSION_W1 float32          
+MW_TRANSMISSION_W2 float32          
+MW_TRANSMISSION_W3 float32          
+MW_TRANSMISSION_W4 float32          
+NOBS_G             int16                      Number of g-band obs     
+NOBS_R             int16                      Number of r-band obs  
+NOBS_Z             int16                      Number of z-band obs
+FRACFLUX_G         float32          
+FRACFLUX_R         float32          
+FRACFLUX_Z         float32          
+PSFDEPTH_G         float32          
+PSFDEPTH_R         float32          
+PSFDEPTH_Z         float32          
+GALDEPTH_G         float32          
+GALDEPTH_R         float32          
+GALDEPTH_Z         float32          
+SHAPEDEV_R         float32          
+SHAPEEXP_R         float32          
+TARGETID           int64                      Unique target ID
+DESI_TARGET        int64                      Dark + calib target selection bits
+BGS_TARGET         int64                      Bright Galaxy Survey TS bits
+MWS_TARGET         int64                      Milky Way Survey TS bits
+HPXPIXEL           int64                      Healpixel ID (NESTED)
+PHOTSYS            char[1]                    N or S
+================== ========== =============== ==================================
 
 
 Notes and Examples
@@ -94,10 +135,10 @@ Notes and Examples
 
 In general, the above format contains:
 
-* Columns that were used by target selection (e.g. DECAM_FLUX)
+* Columns that were used by target selection (e.g. FLUX_G/R/Z)
 * Columns needed by fiber assignment (e.g. RA, DEC)
 * Columns needed for traceability (e.g. BRICKNAME, TARGETID, DESI_TARGET, BGS_TARGET, MWS_TARGET)
 
-TARGETID, DESI_TARGET, BGS_TARGET and MWS_TARGET are created by target selection; the rest are pass through from the original input tractor files
+TARGETID, HPXPIXEL, PHOTSYS, DESI_TARGET, BGS_TARGET and MWS_TARGET are created by target selection; the rest are pass through from the original input tractor files
 
 See http://legacysurvey.org for more details about the columns from input tractor files

--- a/doc/DESI_TARGET/targets.rst
+++ b/doc/DESI_TARGET/targets.rst
@@ -129,6 +129,7 @@ HPXPIXEL           int64                      Healpixel ID (NESTED)
 PHOTSYS            char[1]                    N or S
 ================== ========== =============== ==================================
 
+TODO: finish documenting all columns; in the meantime see http://legacysurvey.org .
 
 Notes and Examples
 ==================
@@ -139,6 +140,6 @@ In general, the above format contains:
 * Columns needed by fiber assignment (e.g. RA, DEC)
 * Columns needed for traceability (e.g. BRICKNAME, TARGETID, DESI_TARGET, BGS_TARGET, MWS_TARGET)
 
-TARGETID, HPXPIXEL, PHOTSYS, DESI_TARGET, BGS_TARGET and MWS_TARGET are created by target selection; the rest are pass through from the original input tractor files
+TARGETID, HPXPIXEL, PHOTSYS, DESI_TARGET, BGS_TARGET and MWS_TARGET are created by target selection; the rest are passed through from the original input tractor files
 
 See http://legacysurvey.org for more details about the columns from input tractor files


### PR DESCRIPTION
Adds DR4 target catalog format, while temporarily keeping old DR3-based format too.  Comments and units could be expanded, but this gets a basic placeholder in there for the new format.