### PR TITLE
add missing file summaries and HDU descriptions

### DIFF
--- a/doc/DESIMODEL/data/focalplane/fiberpos-all.rst
+++ b/doc/DESIMODEL/data/focalplane/fiberpos-all.rst
@@ -2,8 +2,9 @@
 fiberpos-all
 ============
 
-:Summary: A mapping of positioner number to fiber number. An ECSV_
-          version of this file might also be present.
+:Summary: A mapping of positioner number to fiber number, including
+    positions from DESI-0530.
+    An ECSV_ version of this file might also be present.
 :Naming Convention: ``fiberpos-all.fits``
 :Regex: ``fiberpos-all\.fits``
 :File Type: FITS, 472 KB
@@ -13,12 +14,12 @@ fiberpos-all
 Contents
 ========
 
-====== ======== ======== ===================
+====== ======== ======== ==============================
 Number EXTNAME  Type     Contents
-====== ======== ======== ===================
-HDU0_  PRIMARY  IMAGE    *Brief Description*
-HDU1_  FIBERPOS BINTABLE *Brief Description*
-====== ======== ======== ===================
+====== ======== ======== ==============================
+HDU0_  PRIMARY  IMAGE    Empty
+HDU1_  FIBERPOS BINTABLE Fiber positions on focal plane
+====== ======== ======== ==============================
 
 
 FITS Header Units
@@ -29,8 +30,6 @@ HDU0
 
 EXTNAME = PRIMARY
 
-*Summarize the contents of this HDU.*
-
 This HDU has no non-standard required keywords.
 
 Empty HDU.
@@ -40,7 +39,7 @@ HDU1
 
 EXTNAME = FIBERPOS
 
-*Summarize the contents of this HDU.*
+Fiber positions on focal plane
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/DESIMODEL/data/footprint/desi-tiles-randomized.rst
+++ b/doc/DESIMODEL/data/footprint/desi-tiles-randomized.rst
@@ -30,8 +30,6 @@ HDU0
 
 EXTNAME = PRIMARY
 
-*Summarize the contents of this HDU.*
-
 This HDU has no non-standard required keywords.
 
 Empty HDU.
@@ -41,7 +39,8 @@ HDU1
 
 EXTNAME = TILES
 
-*Summarize the contents of this HDU.*
+Tile centers with randomized offsets to wash out large scale patterns from
+regular overlaps.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/DESIMODEL/data/footprint/desi-tiles.rst
+++ b/doc/DESIMODEL/data/footprint/desi-tiles.rst
@@ -30,8 +30,6 @@ HDU0
 
 EXTNAME = PRIMARY
 
-*Summarize the contents of this HDU.*
-
 This HDU has no non-standard required keywords.
 
 Empty HDU.
@@ -41,7 +39,7 @@ HDU1
 
 EXTNAME = TILES
 
-*Summarize the contents of this HDU.*
+Pre-defined DESI tile locations on the sky (i.e. telescope pointings)
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/DESIMODEL/data/inputs/throughput/ZenithExtinction.rst
+++ b/doc/DESIMODEL/data/inputs/throughput/ZenithExtinction.rst
@@ -12,12 +12,12 @@ ZenithExtinction
 Contents
 ========
 
-====== ========== ======== ===================
+====== ========== ======== ======================
 Number EXTNAME    Type     Contents
-====== ========== ======== ===================
-HDU0_  PRIMARY    IMAGE    *Brief Description*
-HDU1_  EXTINCTION BINTABLE *Brief Description*
-====== ========== ======== ===================
+====== ========== ======== ======================
+HDU0_  PRIMARY    IMAGE    Empty
+HDU1_  EXTINCTION BINTABLE Atmospheric Extinction
+====== ========== ======== ======================
 
 
 FITS Header Units
@@ -37,7 +37,7 @@ HDU1
 
 EXTNAME = EXTINCTION
 
-*Summarize the contents of this HDU.*
+Atmospheric extinction in magnitudes per airmass.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/DESIMODEL/data/specpsf/psf-quicksim.rst
+++ b/doc/DESIMODEL/data/specpsf/psf-quicksim.rst
@@ -10,14 +10,14 @@ psf
 Contents
 ========
 
-====== ========== ======== ===================
+====== ========== ======== =======================
 Number EXTNAME    Type     Contents
-====== ========== ======== ===================
-HDU0_  PRIMARY    IMAGE    *Brief Description*
-HDU1_  QUICKSIM-B BINTABLE *Brief Description*
-HDU2_  QUICKSIM-R BINTABLE *Brief Description*
-HDU3_  QUICKSIM-Z BINTABLE *Brief Description*
-====== ========== ======== ===================
+====== ========== ======== =======================
+HDU0_  PRIMARY    IMAGE    Empty
+HDU1_  QUICKSIM-B BINTABLE b-camera PSF parameters
+HDU2_  QUICKSIM-R BINTABLE r-camera PSF parameters
+HDU3_  QUICKSIM-Z BINTABLE z-camera PSF parameters
+====== ========== ======== =======================
 
 
 FITS Header Units
@@ -28,8 +28,6 @@ HDU0
 
 EXTNAME = PRIMARY
 
-*Summarize the contents of this HDU.*
-
 This HDU has no non-standard required keywords.
 
 Empty HDU.
@@ -39,7 +37,7 @@ HDU1
 
 EXTNAME = QUICKSIM-B
 
-*Summarize the contents of this HDU.*
+b-camera PSF parameters.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -60,22 +58,22 @@ WAVEUNIT Angstrom                                 str  Wavelengths in Angstroms
 Required Data Table Columns
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-================= ======= ============ ===================
+================= ======= ============ ===========================================
 Name              Type    Units        Description
-================= ======= ============ ===================
-wavelength        float64 Angstrom     label for field   1
-fwhm_wave         float64 Angstrom     label for field   2
-fwhm_spatial      float64 pixel        label for field   3
-neff_spatial      float64 pixel        label for field   4
-angstroms_per_row float64 Angstrom/row label for field   5
-================= ======= ============ ===================
+================= ======= ============ ===========================================
+wavelength        float64 Angstrom     wavelength
+fwhm_wave         float64 Angstrom     FWHM in wavelength (y) direction
+fwhm_spatial      float64 pixel        FWHM in cross-dispersion (x) direction
+neff_spatial      float64 pixel        Number of effective pixels covered
+angstroms_per_row float64 Angstrom/row Angstroms per CCD pixels at this wavelength
+================= ======= ============ ===========================================
 
 HDU2
 ----
 
 EXTNAME = QUICKSIM-R
 
-*Summarize the contents of this HDU.*
+r-camera PSF parameters.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -96,22 +94,22 @@ WAVEUNIT Angstrom                                 str  Wavelengths in Angstroms
 Required Data Table Columns
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-================= ======= ============ ===================
+================= ======= ============ ===========================================
 Name              Type    Units        Description
-================= ======= ============ ===================
-wavelength        float64 Angstrom     label for field   1
-fwhm_wave         float64 Angstrom     label for field   2
-fwhm_spatial      float64 pixel        label for field   3
-neff_spatial      float64 pixel        label for field   4
-angstroms_per_row float64 Angstrom/row label for field   5
-================= ======= ============ ===================
+================= ======= ============ ===========================================
+wavelength        float64 Angstrom     wavelength
+fwhm_wave         float64 Angstrom     FWHM in wavelength (y) direction
+fwhm_spatial      float64 pixel        FWHM in cross-dispersion (x) direction
+neff_spatial      float64 pixel        Number of effective pixels covered
+angstroms_per_row float64 Angstrom/row Angstroms per CCD pixels at this wavelength
+================= ======= ============ ===========================================
 
 HDU3
 ----
 
 EXTNAME = QUICKSIM-Z
 
-*Summarize the contents of this HDU.*
+z-camera PSF parameters.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -132,15 +130,15 @@ WAVEUNIT Angstrom                                 str  Wavelengths in Angstroms
 Required Data Table Columns
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-================= ======= ============ ===================
+================= ======= ============ ===========================================
 Name              Type    Units        Description
-================= ======= ============ ===================
-wavelength        float64 Angstrom     label for field   1
-fwhm_wave         float64 Angstrom     label for field   2
-fwhm_spatial      float64 pixel        label for field   3
-neff_spatial      float64 pixel        label for field   4
-angstroms_per_row float64 Angstrom/row label for field   5
-================= ======= ============ ===================
+================= ======= ============ ===========================================
+wavelength        float64 Angstrom     wavelength
+fwhm_wave         float64 Angstrom     FWHM in wavelength (y) direction
+fwhm_spatial      float64 pixel        FWHM in cross-dispersion (x) direction
+neff_spatial      float64 pixel        Number of effective pixels covered
+angstroms_per_row float64 Angstrom/row Angstroms per CCD pixels at this wavelength
+================= ======= ============ ===========================================
 
 
 Notes and Examples

--- a/doc/DESIMODEL/data/specpsf/psf.rst
+++ b/doc/DESIMODEL/data/specpsf/psf.rst
@@ -10,19 +10,21 @@ psf
 Contents
 ========
 
-====== ======== ===== ===================
+====== ======== ===== ===============================================
 Number EXTNAME  Type  Contents
-====== ======== ===== ===================
-HDU0_  XCOEFF   IMAGE *Brief Description*
-HDU1_  YCOEFF   IMAGE *Brief Description*
-HDU2_  SPOTS    IMAGE *Brief Description*
-HDU3_  SPOTX    IMAGE *Brief Description*
-HDU4_  SPOTY    IMAGE *Brief Description*
-HDU5_  FIBERPOS IMAGE *Brief Description*
-HDU6_  SPOTPOS  IMAGE *Brief Description*
-HDU7_  SPOTWAVE IMAGE *Brief Description*
-====== ======== ===== ===================
+====== ======== ===== ===============================================
+HDU0_  XCOEFF   IMAGE Legendre coeff for CCD x vs. wavelength
+HDU1_  YCOEFF   IMAGE Legendre coeff for CCD y vs. wavelength
+HDU2_  SPOTS    IMAGE Zemax PSF spots
+HDU3_  SPOTX    IMAGE CCD x locations of spots
+HDU4_  SPOTY    IMAGE CCD y locations of spots
+HDU5_  FIBERPOS IMAGE Location of each fiber along slit
+HDU6_  SPOTPOS  IMAGE Locations along slit where spots were generated
+HDU7_  SPOTWAVE IMAGE Wavelength of generated spots
+====== ======== ===== ===============================================
 
+SPOTS[i,j] is 2D image[y,x] of Zemax spot on the CCD at SPOTX[j], SPOTY[i]
+and along the slit at SPOTPOS[i] which is wavelength SPOTWAVE[i].
 
 FITS Header Units
 =================
@@ -32,7 +34,7 @@ HDU0
 
 EXTNAME = XCOEFF
 
-*Summarize the contents of this HDU.*
+Legendre coeff for CCD x vs. wavelength.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -96,7 +98,7 @@ HDU1
 
 EXTNAME = YCOEFF
 
-*Summarize the contents of this HDU.*
+Legendre coeff for CCD y vs. wavelength.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -120,7 +122,10 @@ HDU2
 
 EXTNAME = SPOTS
 
-*Summarize the contents of this HDU.*
+Zemax simulated spots.
+
+SPOTS[i,j] is 2D image[y,x] of Zemax spot on the CCD at SPOTX[j], SPOTY[i]
+and along the slit at SPOTPOS[i] which is wavelength SPOTWAVE[i].
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -142,7 +147,10 @@ HDU3
 
 EXTNAME = SPOTX
 
-*Summarize the contents of this HDU.*
+X locations of spots.
+
+SPOTS[i,j] is 2D image[y,x] of Zemax spot on the CCD at SPOTX[j], SPOTY[i]
+and along the slit at SPOTPOS[i] which is wavelength SPOTWAVE[i].
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -162,7 +170,10 @@ HDU4
 
 EXTNAME = SPOTY
 
-*Summarize the contents of this HDU.*
+Y locations of spots.
+
+SPOTS[i,j] is 2D image[y,x] of Zemax spot on the CCD at SPOTX[j], SPOTY[i]
+and along the slit at SPOTPOS[i] which is wavelength SPOTWAVE[i].
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -182,7 +193,7 @@ HDU5
 
 EXTNAME = FIBERPOS
 
-*Summarize the contents of this HDU.*
+Location along the slit of each fiber.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -201,7 +212,10 @@ HDU6
 
 EXTNAME = SPOTPOS
 
-*Summarize the contents of this HDU.*
+Location along the slit of each spot.
+
+SPOTS[i,j] is 2D image[y,x] of Zemax spot on the CCD at SPOTX[j], SPOTY[i]
+and along the slit at SPOTPOS[i] which is wavelength SPOTWAVE[i].
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -220,7 +234,10 @@ HDU7
 
 EXTNAME = SPOTWAVE
 
-*Summarize the contents of this HDU.*
+Wavelengths at which each spot was measured.
+
+SPOTS[i,j] is 2D image[y,x] of Zemax spot on the CCD at SPOTX[j], SPOTY[i]
+and along the slit at SPOTPOS[i] which is wavelength SPOTWAVE[i].
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/DESIMODEL/data/throughput/DESI-0347.rst
+++ b/doc/DESIMODEL/data/throughput/DESI-0347.rst
@@ -2,7 +2,7 @@
 DESI-0347
 =========
 
-:Summary: Data related to image spot size. ECSV_ files may also be present.
+:Summary: Focal plane distortion maps. ECSV_ files may also be present.
 :Naming Convention: ``DESI-0347_random_offset_{N}.fits``, where ``{N}`` is
                     the (arbitrary) number of the random realization.
 :Regex: ``DESI-0347_random_offset_[0-9]+\.fits``
@@ -13,14 +13,15 @@ DESI-0347
 Contents
 ========
 
-====== ======= ===== ===================
+====== ======= ===== ========================================
 Number EXTNAME Type  Contents
-====== ======= ===== ===================
-HDU0_  PRIMARY IMAGE *Brief Description*
-HDU1_  XOFFSET IMAGE *Brief Description*
-HDU2_  YOFFSET IMAGE *Brief Description*
-====== ======= ===== ===================
+====== ======= ===== ========================================
+HDU0_  PRIMARY IMAGE Empty
+HDU1_  XOFFSET IMAGE 2D image of x-offsets on the focal plane
+HDU2_  YOFFSET IMAGE 2D image of y-offsets on the focal plane
+====== ======= ===== ========================================
 
+TODO: expand description with links to documentation about how this is used.
 
 FITS Header Units
 =================
@@ -29,8 +30,6 @@ HDU0
 ----
 
 EXTNAME = PRIMARY
-
-*Summarize the contents of this HDU.*
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -48,7 +47,7 @@ HDU1
 
 EXTNAME = XOFFSET
 
-*Summarize the contents of this HDU.*
+2D image of x-offsets on the focal plane.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -79,7 +78,7 @@ HDU2
 
 EXTNAME = YOFFSET
 
-*Summarize the contents of this HDU.*
+2D image of x-offsets on the focal plane.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/DESIMODEL/data/throughput/thru.rst
+++ b/doc/DESIMODEL/data/throughput/thru.rst
@@ -10,14 +10,13 @@ thru
 Contents
 ========
 
-====== ========== ======== ===================
+====== ========== ======== =============================
 Number EXTNAME    Type     Contents
-====== ========== ======== ===================
-HDU0_  PRIMARY    IMAGE    *Brief Description*
-HDU1_  THROUGHPUT BINTABLE *Brief Description*
-HDU2_  FIBERINPUT BINTABLE *Brief Description*
-====== ========== ======== ===================
-
+====== ========== ======== =============================
+HDU0_  PRIMARY    IMAGE    Empty
+HDU1_  THROUGHPUT BINTABLE Throughput model
+HDU2_  FIBERINPUT BINTABLE Geometric loss at fiber input
+====== ========== ======== =============================
 
 FITS Header Units
 =================
@@ -26,8 +25,6 @@ HDU0
 ----
 
 EXTNAME = PRIMARY
-
-*Summarize the contents of this HDU.*
 
 This HDU has no non-standard required keywords.
 
@@ -38,7 +35,7 @@ HDU1
 
 EXTNAME = THROUGHPUT
 
-*Summarize the contents of this HDU.*
+Throughput model.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -59,21 +56,22 @@ EXTNAME  THROUGHPUT        str   extension name
 Required Data Table Columns
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-========== ======= ===== ===========
-Name       Type    Units Description
-========== ======= ===== ===========
-wavelength float64
-throughput float64
-extinction float64
-fiberinput float64
-========== ======= ===== ===========
+========== ======= ======== ===========
+Name       Type    Units    Description
+========== ======= ======== ===========
+wavelength float64 Angstrom Wavelengths
+throughput float64          Throughput losses not due to atmosphere or fiber inputs
+extinction float64          Atmospheric extinction
+fiberinput float64          DEPRECATED; fiber input losses (point-source?)
+========== ======= ======== ===========
 
 HDU2
 ----
 
 EXTNAME = FIBERINPUT
 
-*Summarize the contents of this HDU.*
+Typical fiber input geometric throughput for various object types.
+0 = no transmission; 1 = all light makes it into the fibers.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -89,15 +87,15 @@ EXTNAME FIBERINPUT    str  extension name
 Required Data Table Columns
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-========== ======= ===== ===========
-Name       Type    Units Description
-========== ======= ===== ===========
-wavelength float64
-elg        float64
-lrg        float64
-star       float64
-sky        float64
-========== ======= ===== ===========
+========== ======= ======== ===========
+Name       Type    Units    Description
+========== ======= ======== ===========
+wavelength float64 Angstrom Wavelengths at which loss is modeled
+elg        float64          throughput for typical ELG
+lrg        float64          throughput for typical LRG
+star       float64          throughput for typical point source
+sky        float64          throughput for uniform source
+========== ======= ======== ===========
 
 
 Notes and Examples

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/calibnight/NIGHT/fiberflatnight-CAMERA-NIGHT.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/calibnight/NIGHT/fiberflatnight-CAMERA-NIGHT.rst
@@ -2,9 +2,9 @@
 fiberflatnight-CAMERA-NIGHT
 ===========================
 
-:Summary: *This section should be filled in with a high-level description of
-    this file. In general, you should remove or replace the emphasized text
-    (\*this text is emphasized\*) in this document.*
+:Summary: Relative fiber-to-fiber variations ("fiberflat") as measured by
+    continuum lamp calibration spectra, combined across multiple exposures.
+    Corrected flux = original flux / fiberflat.
 :Naming Convention: ``fiberflatnight-CAMERA-NIGHT.fits``, where ``CAMERA`` is
     *e.g.*, "b0", "r5", etc. and ``NIGHT`` is the observation night in
     YYYYMMDD format.
@@ -14,15 +14,15 @@ fiberflatnight-CAMERA-NIGHT
 Contents
 ========
 
-====== ========== ======== ===================
+====== ========== ======== =================================
 Number EXTNAME    Type     Contents
-====== ========== ======== ===================
-HDU0_  FIBERFLAT  IMAGE    *Brief Description*
-HDU1_  IVAR       IMAGE    *Brief Description*
-HDU2_  MASK       BINTABLE *Brief Description*
-HDU3_  MEANSPEC   IMAGE    *Brief Description*
-HDU4_  WAVELENGTH IMAGE    *Brief Description*
-====== ========== ======== ===================
+====== ========== ======== =================================
+HDU0_  FIBERFLAT  IMAGE    Relative fiber-to-fiber variation
+HDU1_  IVAR       IMAGE    Inverse variance of fiberflat
+HDU2_  MASK       BINTABLE Mask of fiberflat (0=good)
+HDU3_  MEANSPEC   IMAGE    Average spectrum
+HDU4_  WAVELENGTH IMAGE    Wavelength
+====== ========== ======== =================================
 
 
 FITS Header Units
@@ -33,7 +33,7 @@ HDU0
 
 EXTNAME = FIBERFLAT
 
-*Summarize the contents of this HDU.*
+Relative fiber-to-fiber variation.  Corrected flux = original flux / fiberflat.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -65,7 +65,7 @@ HDU1
 
 EXTNAME = IVAR
 
-*Summarize the contents of this HDU.*
+Inverse variance of fiberflat
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -86,7 +86,7 @@ HDU2
 
 EXTNAME = MASK
 
-*Summarize the contents of this HDU.*
+Mask of fiberflat (0=good)
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -109,7 +109,7 @@ HDU3
 
 EXTNAME = MEANSPEC
 
-*Summarize the contents of this HDU.*
+Average continuum lamp spectrum
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -129,7 +129,7 @@ HDU4
 
 EXTNAME = WAVELENGTH
 
-*Summarize the contents of this HDU.*
+Wavelengths at which the fiberflat is measured
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -149,4 +149,9 @@ Data: FITS image [float32, 2645]
 Notes and Examples
 ==================
 
-*Add notes and examples here.  You can also create links to example files.*
+Corrected flux = original flux / fiberflat.
+
+.. code::
+
+  fiberflat = desispec.fiberflat.compute_fiberflat(flatframe)
+  desispec.fiberflat.apply_fiberflat(scienceframe, fiberflat)

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/calib-CAMERA-EXPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/calib-CAMERA-EXPID.rst
@@ -30,7 +30,7 @@ HDU0
 
 EXTNAME = FLUXCALIB
 
-*Summarize the contents of this HDU.*
+Flux calibration model such that calibrated flux = uncalibrated photons / model.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -62,7 +62,7 @@ MJD      58925.11304582807          float
 TRANSPAR 0.7192993760108948         float
 DOSVER   SIM                        str
 FEEVER   SIM                        str
-BUNIT    1e+17 cm2 electron s / erg str   i.e. (electron/Angstrom) / (1e-17 erg/s
+BUNIT    1e+17 cm2 electron s / erg str   i.e. (electron/Angstrom) / (1e-17 erg/(s cm2 Angstrom))
 AIRORVAC vac                        str   Vacuum wavelengths
 CAMERA   r3                         str
 FIBERMIN 1557                       int
@@ -77,7 +77,7 @@ HDU1
 
 EXTNAME = IVAR
 
-*Summarize the contents of this HDU.*
+Inverse variance of flux calibration model.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -98,7 +98,7 @@ HDU2
 
 EXTNAME = MASK
 
-*Summarize the contents of this HDU.*
+Mask of flux calibration model; 0=good.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -121,7 +121,7 @@ HDU3
 
 EXTNAME = WAVELENGTH
 
-*Summarize the contents of this HDU.*
+Wavelengths at which the flux calibration model is evaluated.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/cframe-CAMERA-EXPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/cframe-CAMERA-EXPID.rst
@@ -23,7 +23,7 @@ HDU2_  MASK       IMAGE    Mask (0 = good)
 HDU3_  WAVELENGTH IMAGE    wavelength in Angstrom
 HDU4_  RESOLUTION IMAGE    Resolution Matrix
 HDU5_  FIBERMAP   BINTABLE Fibermap details propagated from :doc:`fibermap-EXPID.fits <../../../../../DESI_SPECTRO_DATA/NIGHT/fibermap-EXPID>`
-HDU6_  SCORES     BINTABLE *Brief Description*
+HDU6_  SCORES     BINTABLE Quality Assurance scores
 ====== ========== ======== ===================
 
 
@@ -35,7 +35,7 @@ HDU0
 
 EXTNAME = FLUX
 
-*Summarize the contents of this HDU.*
+Calibrated spectral flux in 1e-17 erg / (s cm2 Angstrom).
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -82,7 +82,7 @@ HDU1
 
 EXTNAME = IVAR
 
-*Summarize the contents of this HDU.*
+Inverse variance of flux (i.e. 1/error^2).
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -103,7 +103,9 @@ HDU2
 
 EXTNAME = MASK
 
-*Summarize the contents of this HDU.*
+Mask of spectra; 0=good.
+
+TODO: add documentation link to what bits mean what.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -126,7 +128,7 @@ HDU3
 
 EXTNAME = WAVELENGTH
 
-*Summarize the contents of this HDU.*
+Wavelengths at which flux is measured.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -147,7 +149,9 @@ HDU4
 
 EXTNAME = RESOLUTION
 
-*Summarize the contents of this HDU.*
+Diagonal elements of convolution matrix describing spectral resolution.
+
+TODO: add code example for using this.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -169,7 +173,9 @@ HDU5
 
 EXTNAME = FIBERMAP
 
-*Summarize the contents of this HDU.*
+Fibermap of what targets were assigned to what fibers.
+
+NOTE: This format will be updated soon, e.g. to track FLUX instead of MAG.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -223,7 +229,8 @@ HDU6
 
 EXTNAME = SCORES
 
-*Summarize the contents of this HDU.*
+Scores / metrics measured from the spectra for use in QA and systematics
+studies.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/fiberflat-CAMERA-EXPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/fiberflat-CAMERA-EXPID.rst
@@ -21,7 +21,7 @@ HDU3_  MEANSPEC   IMAGE average spectrum[nwave]
 HDU4_  WAVELENGTH IMAGE wavelength grid[nwave] in Angstroms
 ====== ========== ===== ===================
 
-Current pipeline (as of 2016-06-16) writes HDU0 with EXTNAME=FLUX, having
+TODO: Current pipeline (as of 2016-06-16) writes HDU0 with EXTNAME=FLUX, having
 inherited that from the input frame.  That should be changed to FIBERFLAT
 (as described above) or no HDU 0 EXTNAME (formal FITS standard).
 
@@ -114,7 +114,8 @@ HDU3
 
 EXTNAME = MEANSPEC
 
-*Summarize the contents of this HDU.*
+Average flat lamp spectrum of fibers in this frame.  Fiberflat is relative
+to this mean spectrum.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/frame-CAMERA-EXPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/frame-CAMERA-EXPID.rst
@@ -100,7 +100,9 @@ HDU2
 
 EXTNAME = MASK
 
-*Summarize the contents of this HDU.*
+Mask of spectral data; 0=good.
+
+TODO: Add link to definition of which bits mean what.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/sky-CAMERA-EXPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/sky-CAMERA-EXPID.rst
@@ -19,7 +19,7 @@ HDU0_  SKY        IMAGE sky model in photons/bin
 HDU1_  IVAR       IMAGE inverse variance ``(photons/bin)^-2``
 HDU2_  MASK       IMAGE sky mask (0 = good)
 HDU3_  WAVELENGTH IMAGE wavelength in Angstrom
-HDU4_  STATIVAR   IMAGE *Brief Description*
+HDU4_  STATIVAR   IMAGE statistical-only inverse variance of sky model
 ====== ========== ===== ===================
 
 
@@ -31,7 +31,7 @@ HDU0
 
 EXTNAME = SKY
 
-*Summarize the contents of this HDU.*
+sky model in photons/bin
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -78,7 +78,7 @@ HDU1
 
 EXTNAME = IVAR
 
-*Summarize the contents of this HDU.*
+inverse variance of sky model ``(photons/bin)^-2``
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -99,7 +99,7 @@ HDU2
 
 EXTNAME = MASK
 
-*Summarize the contents of this HDU.*
+sky mask (0 = good)
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -122,7 +122,7 @@ HDU3
 
 EXTNAME = WAVELENGTH
 
-*Summarize the contents of this HDU.*
+wavelength in Angstrom
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -142,7 +142,7 @@ HDU4
 
 EXTNAME = STATIVAR
 
-*Summarize the contents of this HDU.*
+statistical-only inverse variance of sky model
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/stdstars-SPECTROGRAPH-EXPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/stdstars-SPECTROGRAPH-EXPID.rst
@@ -20,7 +20,7 @@ HDU0_  FLUX       IMAGE    stdstar flux[nstd, nwave] in erg/s/cm^2/Angstrom
 HDU1_  WAVELENGTH IMAGE    wavelength grid used, Angstroms
 HDU2_  FIBERS     IMAGE    1D array of which fibers these models correspond to
 HDU3_  METADATA   BINTABLE metadata from input standard star templates
-HDU4_  COEFF      IMAGE    *Brief Description*
+HDU4_  COEFF      IMAGE    Linear coefficients of stdstar model fit
 ====== ========== ======== ===================
 
 
@@ -32,7 +32,7 @@ HDU0
 
 EXTNAME = FLUX
 
-*Summarize the contents of this HDU.*
+Best fit standard star model flux.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -54,7 +54,7 @@ HDU1
 
 EXTNAME = WAVELENGTH
 
-*Summarize the contents of this HDU.*
+Wavelength grid used in Angstroms.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -75,7 +75,7 @@ HDU2
 
 EXTNAME = FIBERS
 
-*Summarize the contents of this HDU.*
+Fibers used for fit.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -95,7 +95,7 @@ HDU3
 
 EXTNAME = METADATA
 
-*Summarize the contents of this HDU.*
+Metadata about best fit standard star models.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -129,7 +129,9 @@ HDU4
 
 EXTNAME = COEFF
 
-*Summarize the contents of this HDU.*
+Linear coefficients of stdstar model fit
+
+TODO: add example of what that means
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/zcatalog-SPECPROD.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/zcatalog-SPECPROD.rst
@@ -2,8 +2,9 @@
 zcatalog-SPECPROD
 =================
 
-:Summary: This file summarizes all
-    :doc:`zbest <./spectra-NSIDE/PIXGROUP/PIXNUM/zbest-NSIDE-PIXNUM>` files.
+:Summary: This file concatenates all
+    :doc:`zbest <./spectra-NSIDE/PIXGROUP/PIXNUM/zbest-NSIDE-PIXNUM>` files
+    and then cross matches them with the input target catalog.
 :Naming Convention: ``zcatalog-{SPECPROD}.fits``, where ``{SPECPROD}`` is the
     :envvar:`SPECPROD` name of the reduction run.
 :Regex: ``zcatalog-[a-z0-9_-]+\.fits``
@@ -12,12 +13,12 @@ zcatalog-SPECPROD
 Contents
 ========
 
-====== ======== ======== ===================
+====== ======== ======== ===========================================
 Number EXTNAME  Type     Contents
-====== ======== ======== ===================
-HDU0_  PRIMARY  IMAGE    *Brief Description*
-HDU1_  ZCATALOG BINTABLE *Brief Description*
-====== ======== ======== ===================
+====== ======== ======== ===========================================
+HDU0_  PRIMARY  IMAGE    Empty
+HDU1_  ZCATALOG BINTABLE Redshift catalog joined with target catalog
+====== ======== ======== ===========================================
 
 
 FITS Header Units
@@ -37,18 +38,19 @@ HDU1
 
 EXTNAME = ZCATALOG
 
-The summarized redshift data for all
-:doc:`zbest <./spectra-NSIDE/PIXGROUP/PIXNUM/zbest-NSIDE-PIXNUM>` files.
+The concatenated redshift data for all
+:doc:`zbest <./spectra-NSIDE/PIXGROUP/PIXNUM/zbest-NSIDE-PIXNUM>` files,
+cross matched with the original input target catalog.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-====== ============= ==== =======================
+====== ============= ==== =================================
 KEY    Example Value Type Comment
-====== ============= ==== =======================
+====== ============= ==== =================================
 NAXIS1 332           int  width of table in bytes
-NAXIS2 44215         int  number of rows in table
-====== ============= ==== =======================
+NAXIS2 44215         int  number of targets (rows) in table
+====== ============= ==== =================================
 
 Required Data Table Columns
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This PR fills in all the "Summarize the contents of this HDU" and "Brief Description" placeholders in the current data model.  When this is approved and merged we can tag this as the datamodel version that describes the state of the 18.3 software release.