### PR TITLE
Remove references to masked HDUs

### DIFF
--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/calibnight/NIGHT/fiberflatnight-CAMERA-NIGHT.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/calibnight/NIGHT/fiberflatnight-CAMERA-NIGHT.rst
@@ -102,7 +102,7 @@ CHECKSUM LmE7NjE7LjE7LjE7 str  HDU checksum updated 2018-03-29T21:38:41
 DATASUM  7014250          str  data unit checksum updated 2018-03-29T21:38:41
 ======== ================ ==== ==============================================
 
-Data: FITS image [int32 (compressed), 8x500]
+Data: FITS image [int32, 8x500]
 
 HDU3
 ----

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/calibnight/NIGHT/fiberflatnight-CAMERA-NIGHT.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/calibnight/NIGHT/fiberflatnight-CAMERA-NIGHT.rst
@@ -86,7 +86,9 @@ HDU2
 
 EXTNAME = MASK
 
-Mask of fiberflat (0=good)
+Mask of fiberflat (0=good).
+
+Prior to desispec/0.24.0 and software release 18.9, the MASK HDU was compressed.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/calib-CAMERA-EXPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/calib-CAMERA-EXPID.rst
@@ -114,7 +114,7 @@ CHECKSUM YeVDcZTCZbTCaZTC str  HDU checksum updated 2018-03-01T15:08:08
 DATASUM  661250           str  data unit checksum updated 2018-03-01T15:08:08
 ======== ================ ==== ==============================================
 
-Data: FITS image [int32 (compressed), 2645x500]
+Data: FITS image [int32, 2645x500]
 
 HDU3
 ----

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/calib-CAMERA-EXPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/calib-CAMERA-EXPID.rst
@@ -100,6 +100,8 @@ EXTNAME = MASK
 
 Mask of flux calibration model; 0=good.
 
+Prior to desispec/0.24.0 and software release 18.9, the MASK HDU was compressed.
+
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/cframe-CAMERA-EXPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/cframe-CAMERA-EXPID.rst
@@ -105,6 +105,8 @@ EXTNAME = MASK
 
 Mask of spectra; 0=good.
 
+Prior to desispec/0.24.0 and software release 18.9, the MASK HDU was compressed.
+
 TODO: add documentation link to what bits mean what.
 
 Required Header Keywords

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/cframe-CAMERA-EXPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/cframe-CAMERA-EXPID.rst
@@ -121,7 +121,7 @@ CHECKSUM odSnqZPlodPloZPl str  HDU checksum updated 2018-03-01T15:08:14
 DATASUM  749750           str  data unit checksum updated 2018-03-01T15:08:14
 ======== ================ ==== ==============================================
 
-Data: FITS image [int32 (compressed), 2999x500]
+Data: FITS image [int32, 2999x500]
 
 HDU3
 ----

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/fiberflat-CAMERA-EXPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/fiberflat-CAMERA-EXPID.rst
@@ -93,6 +93,8 @@ EXTNAME = MASK
 
 Mask of the fiberflat; 0=good.
 
+Prior to desispec/0.24.0 and software release 18.9, the MASK HDU was compressed.
+
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/fiberflat-CAMERA-EXPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/fiberflat-CAMERA-EXPID.rst
@@ -107,7 +107,7 @@ CHECKSUM FcV3FZT2FbT2FZT2 str  HDU checksum updated 2016-06-10T22:02:54
 DATASUM  743774           str  data unit checksum updated 2016-06-10T22:02:54
 ======== ================ ==== ==============================================
 
-Data: FITS image [int32 (compressed), 2975x500]
+Data: FITS image [int32, 2975x500]
 
 HDU3
 ----

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/frame-CAMERA-EXPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/frame-CAMERA-EXPID.rst
@@ -102,6 +102,8 @@ EXTNAME = MASK
 
 Mask of spectral data; 0=good.
 
+Prior to desispec/0.24.0 and software release 18.9, the MASK HDU was compressed.
+
 TODO: Add link to definition of which bits mean what.
 
 Required Header Keywords

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/frame-CAMERA-EXPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/frame-CAMERA-EXPID.rst
@@ -118,7 +118,7 @@ CHECKSUM gaU7iZS4gaS4gWS4 str  HDU checksum updated 2016-06-10T16:57:58
 DATASUM  737750           str  data unit checksum updated 2016-06-10T16:57:58
 ======== ================ ==== ==============================================
 
-Data: FITS image [int32 (compressed), 2951x500]
+Data: FITS image [int32, 2951x500]
 
 HDU3
 ----

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/qframe-CAMERA-EXPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/qframe-CAMERA-EXPID.rst
@@ -2,7 +2,7 @@
 qframe-CAMERA-EXPID.fits
 ========================
 
-:Summary: QFrame files contain the raw extracted electrons or calibrated flux from DESI data. They are the output of the fast row-by-row extractions, such that each fiber has a different wavelength array. 
+:Summary: QFrame files contain the raw extracted electrons or calibrated flux from DESI data. They are the output of the fast row-by-row extractions, such that each fiber has a different wavelength array.
 :Naming Convention: ``qframe-{CAMERA}-{EXPID}.fits``, where ``{CAMERA}`` is
     one of the spectrograph cameras (*e.g.* ``z1``) and ``{EXPID}``
     is the 8-digit exposure ID.
@@ -117,14 +117,14 @@ CHECKSUM gaU7iZS4gaS4gWS4 str  HDU checksum updated 2016-06-10T16:57:58
 DATASUM  737750           str  data unit checksum updated 2016-06-10T16:57:58
 ======== ================ ==== ==============================================
 
-Data: FITS image [int32 (compressed), 2951x500]
+Data: FITS image [int32, 2951x500]
 
 HDU3
 ----
 
 EXTNAME = SIGMA
 
-LSF sigma[nspec, nwave], in CCD pixel units. 
+LSF sigma[nspec, nwave], in CCD pixel units.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/qframe-CAMERA-EXPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/qframe-CAMERA-EXPID.rst
@@ -101,6 +101,8 @@ EXTNAME = MASK
 
 Mask of spectral data; 0=good.
 
+Prior to desispec/0.24.0 and software release 18.9, the MASK HDU was compressed.
+
 TODO: Add link to definition of which bits mean what.
 
 Required Header Keywords

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/sky-CAMERA-EXPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/sky-CAMERA-EXPID.rst
@@ -99,7 +99,9 @@ HDU2
 
 EXTNAME = MASK
 
-sky mask (0 = good)
+Sky mask (0 = good).
+
+Prior to desispec/0.24.0 and software release 18.9, the MASK HDU was compressed.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/sky-CAMERA-EXPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/sky-CAMERA-EXPID.rst
@@ -115,7 +115,7 @@ CHECKSUM 0dTm2ZQl0bQl0ZQl str  HDU checksum updated 2018-03-01T15:04:16
 DATASUM  749750           str  data unit checksum updated 2018-03-01T15:04:16
 ======== ================ ==== ==============================================
 
-Data: FITS image [int32 (compressed), 2999x500]
+Data: FITS image [int32, 2999x500]
 
 HDU3
 ----

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/spectra-NSIDE/PIXGROUP/PIXNUM/spectra-NSIDE-PIXNUM.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/spectra-NSIDE/PIXGROUP/PIXNUM/spectra-NSIDE-PIXNUM.rst
@@ -235,7 +235,9 @@ HDU06
 
 EXTNAME = B_MASK
 
-Mask[nspec,nwave] of b-channel flux array
+Mask[nspec,nwave] of b-channel flux array.
+
+Prior to desispec/0.24.0 and software release 18.9, the B_MASK HDU was compressed.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -349,7 +351,9 @@ HDU11
 
 EXTNAME = R_MASK
 
-Mask[nspec,nwave] of r-channel flux array
+Mask[nspec,nwave] of r-channel flux array.
+
+Prior to desispec/0.24.0 and software release 18.9, the R_MASK HDU was compressed.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -452,7 +456,9 @@ HDU16
 
 EXTNAME = Z_MASK
 
-Mask[nspec,nwave] of z-channel flux array
+Mask[nspec,nwave] of z-channel flux array.
+
+Prior to desispec/0.24.0 and software release 18.9, the Z_MASK HDU was compressed.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/spectra-NSIDE/PIXGROUP/PIXNUM/spectra-NSIDE-PIXNUM.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/spectra-NSIDE/PIXGROUP/PIXNUM/spectra-NSIDE-PIXNUM.rst
@@ -250,7 +250,7 @@ BZERO    2147483648       int
 BSCALE   1                int
 ======== ================ ==== ==============================================
 
-Data: FITS image [int32 (compressed), 2975x5550]
+Data: FITS image [int32, 2975x5550]
 
 HDU07
 -----
@@ -364,7 +364,7 @@ BZERO    2147483648       int
 BSCALE   1                int
 ======== ================ ==== ==============================================
 
-Data: FITS image [int32 (compressed), 2975x5550]
+Data: FITS image [int32, 2975x5550]
 
 HDU12
 -----
@@ -467,7 +467,7 @@ BZERO    2147483648       int
 BSCALE   1                int
 ======== ================ ==== ==============================================
 
-Data: FITS image [int32 (compressed), 2975x5550]
+Data: FITS image [int32, 2975x5550]
 
 HDU17
 -----

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,7 @@ desidatamodel Change Log
 18.9 (unreleased)
 -----------------
 
+* ``MASK`` HDUs will no longer be compressed (PR `#60`_).
 * Deprecate ``DESI_TARGET`` files (``sky``, ``stdstar``) that aren't in use (PR `#59`_).
 * Describe apertures in the skies file as "radius" not "size" (PR `#59`_).
 * Add randoms/gfas/skies/pixweight files to the ``DESI_TARGET`` model (PR `#57`_).
@@ -14,6 +15,7 @@ desidatamodel Change Log
 .. _`#54`: https://github.com/desihub/desidatamodel/pull/54
 .. _`#57`: https://github.com/desihub/desidatamodel/pull/57
 .. _`#59`: https://github.com/desihub/desidatamodel/pull/59
+.. _`#60`: https://github.com/desihub/desidatamodel/pull/60
 
 18.6 (2018-07-20)
 -----------------


### PR DESCRIPTION
This PR is a companion to desihub/desispec#696.  Mask HDUs will no longer be compressed.