### PR TITLE
Populate the data model for the zmtl files

### DIFF
--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/tiles/GROUPTYPE/TILEID/GROUPID/zmtl-SPECTROGRAPH-TILEID-GROUPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/tiles/GROUPTYPE/TILEID/GROUPID/zmtl-SPECTROGRAPH-TILEID-GROUPID.rst
@@ -1,11 +1,13 @@
-=====================================
-zmtl-SPECTROGRAPH-TILEID-GROUPID.fits
-=====================================
+=========================================
+zmtl-SPECTROGRAPH-TILEID-thruGROUPID.fits
+=========================================
 
-:Summary: *This section should be filled in with a high-level description of
-    this file. In general, you should remove or replace the emphasized text
-    (\*this text is emphasized\*) in this document.*
-:Naming Convention: ``zmtl-SPECTROGRAPH-TILEID-GROUPID.fits``, where
+:Summary: The ``zmtl`` files contain information about redshifts used by the
+	  :doc:`MTL ("Merged Target List") process </SURVEYOPS/mtl/index>` to update
+	  the observational state of targets in the MTL ledgers. In particular,
+	  the redshift information is crucial for deciding whether a target
+	  is a Lyman-alpha quasar that requires additional DESI observations.
+:Naming Convention: ``zmtl-SPECTROGRAPH-TILEID-thruGROUPID.fits``, where
     ``SPECTROGRAPH`` is the spectrograph ID, ``TILEID`` is the tile number and
     ``GROUPID`` depends on the ``GROUPTYPE`` of the tile coadd.
 :Regex: ``zmtl-[0-9]-[0-9]+-(thru|)[0-9]{8}\.fits``
@@ -17,8 +19,8 @@ Contents
 ====== ======= ======== ===================
 Number EXTNAME Type     Contents
 ====== ======= ======== ===================
-HDU0_          IMAGE    *Brief Description*
-HDU1_  ZMTL    BINTABLE *Brief Description*
+HDU0_  PRIMARY IMAGE    Empty
+HDU1_  ZMTL    BINTABLE Redshifts to inform MTL updates
 ====== ======= ======== ===================
 
 
@@ -28,7 +30,7 @@ FITS Header Units
 HDU0
 ----
 
-*Summarize the contents of this HDU.*
+EXTNAME = PRIMARY
 
 This HDU has no non-standard required keywords.
 
@@ -39,7 +41,7 @@ HDU1
 
 EXTNAME = ZMTL
 
-*Summarize the contents of this HDU.*
+Redshifts to inform MTL updates
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -53,12 +55,12 @@ Required Header Keywords
     ======== ========================================================================================== ==== =======================
     NAXIS1   112                                                                                        int  width of table in bytes
     NAXIS2   500                                                                                        int  number of rows in table
-    QN_ADDED T                                                                                          bool
-    SQ_ADDED F                                                                                          bool
-    AB_ADDED F                                                                                          bool
-    ZC_ADDED F                                                                                          bool
-    QNMODFIL /global/cfs/cdirs/desi/target/catalogs/lya/qn_models/qn_train_coadd_indtrain_0_0_boss10.h5 str
-    BADPTLQA F                                                                                          bool
+    QN_ADDED T                                                                                          bool ``True`` if `QuasarNET`_ information included
+    SQ_ADDED F                                                                                          bool ``True`` if `SQUEzE`_ information included
+    AB_ADDED F                                                                                          bool ``True`` if absorption line information included
+    ZC_ADDED F                                                                                          bool ``True`` if combined redshift information included
+    QNMODFIL /global/cfs/cdirs/desi/target/catalogs/lya/qn_models/qn_train_coadd_indtrain_0_0_boss10.h5 str  Filename of `QuasarNET`_ model
+    BADPTLQA F                                                                                          bool ``True`` if all fibers on a petal were masked
     ======== ========================================================================================== ==== =======================
 
 Required Data Table Columns
@@ -69,35 +71,35 @@ Required Data Table Columns
 ==================== ======= ===== ===================
 Name                 Type    Units Description
 ==================== ======= ===== ===================
-RA                   float64 deg   label for field   1
-DEC                  float64 deg   label for field   2
-TARGETID             int64         label for field   3
-SV1_DESI_TARGET [1]_ int64         label for field   4
-SV1_BGS_TARGET [1]_  int64         label for field   5
-SV1_MWS_TARGET [1]_  int64         label for field   6
-SV1_SCND_TARGET [1]_ int64         label for field   7
-SV3_DESI_TARGET [1]_ int64         label for field   4
-SV3_BGS_TARGET [1]_  int64         label for field   5
-SV3_MWS_TARGET [1]_  int64         label for field   6
-SV3_SCND_TARGET [1]_ int64         label for field   7
-DESI_TARGET [1]_     int64         label for field   4
-BGS_TARGET [1]_      int64         label for field   5
-MWS_TARGET [1]_      int64         label for field   6
-SCND_TARGET  [1]_    int64         label for field   7
-Z                    float64       label for field   8
-ZWARN                int64         label for field   9
-SPECTYPE             char[6]       label for field  10
-DELTACHI2            float64       label for field  11
-NUMOBS               int32         label for field  12
-ZTILEID              int32         label for field  13
-Z_QN                 float64       label for field  14
-Z_QN_CONF            float64       label for field  15
-IS_QSO_QN            int16         label for field  16
+RA                   float64 deg   Right ascension
+DEC                  float64 deg   Declination
+TARGETID             int64         Unique targeting ID
+DESI_TARGET [1]_     int64         DESI (dark time program) target selection bitmask
+BGS_TARGET [1]_      int64         BGS (bright time program) target selection bitmask
+MWS_TARGET [1]_      int64         MWS (bright time program) target selection bitmask
+SCND_TARGET  [1]_    int64         SCND (secondary program) target selection bitmask
+Z                    float64       Redshift from ``Redrock``
+ZWARN                int64         Redshift warning bimask
+SPECTYPE             char[6]       Spectroscopic classification from ``Redrock``
+DELTACHI2            float64       Chi-squared difference between the first- and second-best redshifts from ``Redrock``
+NUMOBS               int32         Number of spectroscopic observations (on this specific, single tile)
+ZTILEID              int32         Unique tile ID (identical to ``TILEID``)
+Z_QN                 float64       Redshift from `QuasarNET`_
+Z_QN_CONF            float64       Redshift confidence from `QuasarNET`_
+IS_QSO_QN            int16         Spectroscopic classification	from `QuasarNET`_ (1 for a quasar)
 ==================== ======= ===== ===================
 
-.. [1] Optional
+.. [1] ``TARGET`` columns are preceded by the survey ``PHASE`` except in the case of Main Survey files
+       (i.e. ``DESI_TARGET`` is called ``SV1_DESI_TARGET`` when the survey ``PHASE`` is ``sv1``).
+
 
 Notes and Examples
 ==================
 
-*Add notes and examples here.  You can also create links to example files.*
+See the DESI Survey Operations paper (Schlafly et al., in preparation) for
+details of how the quantities in the ``zmtl`` files are used to update the
+observational state of a target in the MTL ledgers.
+
+
+.. _`QuasarNET`: https://ui.adsabs.harvard.edu/abs/2018arXiv180809955B/abstract
+.. _`SQUEzE`: https://ui.adsabs.harvard.edu/abs/2020MNRAS.496.4931P/abstract

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/tiles/GROUPTYPE/TILEID/GROUPID/zmtl-SPECTROGRAPH-TILEID-GROUPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/tiles/GROUPTYPE/TILEID/GROUPID/zmtl-SPECTROGRAPH-TILEID-GROUPID.rst
@@ -74,6 +74,14 @@ Name                 Type    Units Description
 RA                   float64 deg   Right ascension
 DEC                  float64 deg   Declination
 TARGETID             int64         Unique targeting ID
+SV1_DESI_TARGET [1]_ int64         DESI (dark time program) target selection bitmask (sv1 phase of DESI Survey Validation)
+SV1_BGS_TARGET [1]_  int64         BGS (bright time program) target selection bitmask (sv1 phase of DESI Survey Validation)
+SV1_MWS_TARGET [1]_  int64         MWS (bright time program) target selection bitmask (sv1 phase of DESI Survey Validation)
+SV1_SCND_TARGET [1]_ int64         SCND (secondary program) target selection bitmask (sv1 phase of DESI Survey Validation)
+SV3_DESI_TARGET [1]_ int64         DESI (dark time program) target selection bitmask (sv3 phase of DESI Survey Validation)
+SV3_BGS_TARGET [1]_  int64         BGS (bright time program) target selection bitmask (sv3 phase of DESI Survey Validation)
+SV3_MWS_TARGET [1]_  int64         MWS (bright time program) target selection bitmask (sv3 phase of DESI Survey Validation)
+SV3_SCND_TARGET [1]_ int64         SCND (secondary program) target selection bitmask (sv3 phase of DESI Survey Validation)
 DESI_TARGET [1]_     int64         DESI (dark time program) target selection bitmask
 BGS_TARGET [1]_      int64         BGS (bright time program) target selection bitmask
 MWS_TARGET [1]_      int64         MWS (bright time program) target selection bitmask
@@ -89,7 +97,8 @@ Z_QN_CONF            float64       Redshift confidence from `QuasarNET`_
 IS_QSO_QN            int16         Spectroscopic classification	from `QuasarNET`_ (1 for a quasar)
 ==================== ======= ===== ===================
 
-.. [1] ``TARGET`` columns are preceded by the survey ``PHASE`` except in the case of Main Survey files
+.. [1] Only `either` the four ``SV1``, ``SV3`` `or` Main Survey columns will be present. ``TARGET``
+       bitmask columns are preceded by the survey ``PHASE`` except in the case of Main Survey files
        (i.e. ``DESI_TARGET`` is called ``SV1_DESI_TARGET`` when the survey ``PHASE`` is ``sv1``).
 
 

--- a/doc/DESI_TARGET/TARG_DIR/DR/VERSION/targets/PHASE/RESOLVE/OBSCON/PHASEtargets-OBSCON-RESOLVE-hp-HP.rst
+++ b/doc/DESI_TARGET/TARG_DIR/DR/VERSION/targets/PHASE/RESOLVE/OBSCON/PHASEtargets-OBSCON-RESOLVE-hp-HP.rst
@@ -194,16 +194,19 @@ PMDEC                             float32     mas / yr              Reference ca
 PMDEC_IVAR                        float32     yr^2 / mas^2          Inverse variance of PMDEC
 PHOTSYS                           char[1]                           'N' for the MzLS/BASS photometric system, 'S' for DECaLS
 TARGETID                          int64                             Unique targeting ID
-DESI_TARGET                       int64                             DESI (dark time program) target selection bitmask
-BGS_TARGET                        int64                             BGS (bright time program) target selection bitmask
-MWS_TARGET                        int64                             MWS (bright time program) target selection bitmask
+DESI_TARGET [1]_                  int64                             DESI (dark time program) target selection bitmask
+BGS_TARGET  [1]_                  int64                             BGS (bright time program) target selection bitmask
+MWS_TARGET  [1]_                  int64                             MWS (bright time program) target selection bitmask
 SUBPRIORITY                       float64                           Random subpriority [0-1] to break assignment ties
 OBSCONDITIONS                     int64                             Flag target to be observed in combinations of dark/bright observing layer
 PRIORITY_INIT                     int64                             Initial priority for target calculated across target selection bitmasks and OBSCONDITIONS
 NUMOBS_INIT                       int64                             Initial number of observations for target calculated across target selection bitmasks and OBSCONDITIONS
-SCND_TARGET                       int64                             SCND (secondary program) target selection bitmask
+SCND_TARGET [1]_                  int64                             SCND (secondary program) target selection bitmask
 HPXPIXEL                          int64                             HEALPixel containing target at HPXNSIDE
 ================================= =========== ===================== ===================
+
+.. [1] ``TARGET`` columns are preceded by the survey ``PHASE`` except in the case of Main Survey files
+       (i.e. ``DESI_TARGET`` is called ``SV1_DESI_TARGET`` when the survey ``PHASE`` is ``sv1``).
 
 HDU2
 ----

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,15 +5,17 @@ desidatamodel Change Log
 22.5 (unreleased)
 -----------------
 
-* Update data model for target files to reflect ets/dr9 release (PR `#105`_).
+* Populate the data model for the zmtl files (PR `#130`_).
 * Improve documenetation of ``emline`` files (PR `#128`_).
 * Add documentation of various calibration files (PR `#127`_).
 * Further cleanup of ``fuji`` and ``guadalupe`` header keywords and columns (PR `#126`_).
+* Update data model for target files to reflect ets/dr9 release (PR `#105`_).
 
 .. _`#105`: https://github.com/desihub/desidatamodel/pull/105
 .. _`#126`: https://github.com/desihub/desidatamodel/pull/126
 .. _`#127`: https://github.com/desihub/desidatamodel/pull/127
 .. _`#128`: https://github.com/desihub/desidatamodel/pull/128
+.. _`#130`: https://github.com/desihub/desidatamodel/pull/130
 
 22.2 (2022-05-31)
 -----------------


### PR DESCRIPTION
This PR populates/updates the data model for the zmtl files.

It also adds a note to the target files about how the `DESI_TARGET` bitmask columns can be `SVX_DESI_TARGET`, depending on the phase of the survey.