### PR TITLE
Change nanomaggies to nanomaggy in targeting files

### DIFF
--- a/doc/DESI_TARGET/SCND_DIR/PHASE/outdata/VERSION/OBSCON/BITNAME.rst
+++ b/doc/DESI_TARGET/SCND_DIR/PHASE/outdata/VERSION/OBSCON/BITNAME.rst
@@ -77,9 +77,9 @@ PMRA                              float32     mas / yr         Proper motion in 
 PMDEC                             float32     mas / yr         Proper motion in the Dec direction
 REF_EPOCH                         float32     yr               Astrometric reference epoch. Defaults to 2015.5.
 OVERRIDE                          bool                         If ``True`` do not match to and accept an existing primary target. Instead, always generate a new ``TARGETID``.
-FLUX_G                            float32     nanomaggies      `LS`_ flux from tractor input (g)
-FLUX_R                            float32     nanomaggies      `LS`_ flux from tractor input (r)
-FLUX_Z                            float32     nanomaggies      `LS`_ flux from tractor input (z)
+FLUX_G                            float32     nanomaggy        `LS`_ flux from tractor input (g)
+FLUX_R                            float32     nanomaggy        `LS`_ flux from tractor input (r)
+FLUX_Z                            float32     nanomaggy        `LS`_ flux from tractor input (z)
 PARALLAX                          float32     mas              Reference catalog parallax
 GAIA_PHOT_G_MEAN_MAG              float32     mag              `Gaia`_ G band magnitude
 GAIA_PHOT_BP_MEAN_MAG             float32     mag              `Gaia`_ BP band magnitude

--- a/doc/DESI_TARGET/SCND_DIR/PHASE/outdata/VERSION/priminfo-DR-VERSION/targets-no-obscon-hp-HP.rst
+++ b/doc/DESI_TARGET/SCND_DIR/PHASE/outdata/VERSION/priminfo-DR-VERSION/targets-no-obscon-hp-HP.rst
@@ -69,9 +69,9 @@ PMRA                              float32     mas / yr              Proper motio
 PMDEC                             float32     mas / yr              Proper motion in the Dec direction
 REF_EPOCH                         float32     yr                    Astrometric reference epoch. Typically 2015.5.
 OVERRIDE                          bool                              If ``True`` do not match to and accept an existing primary target. Instead, always generate a new ``TARGETID``
-FLUX_G                            float32     nanomaggies           `LS`_ flux from tractor input (g)
-FLUX_R                            float32     nanomaggies           `LS`_ flux from tractor input (r)
-FLUX_Z                            float32     nanomaggies           `LS`_ flux from tractor input (z)
+FLUX_G                            float32     nanomaggy             `LS`_ flux from tractor input (g)
+FLUX_R                            float32     nanomaggy             `LS`_ flux from tractor input (r)
+FLUX_Z                            float32     nanomaggy             `LS`_ flux from tractor input (z)
 PARALLAX                          float32     mas                   Reference catalog parallax
 GAIA_PHOT_G_MEAN_MAG              float32     mag                   `Gaia`_ G band magnitude
 GAIA_PHOT_BP_MEAN_MAG             float32     mag                   `Gaia`_ BP band magnitude

--- a/doc/DESI_TARGET/TARG_DIR/DR/VERSION/gfas/gfas-hp-HP.rst
+++ b/doc/DESI_TARGET/TARG_DIR/DR/VERSION/gfas/gfas-hp-HP.rst
@@ -85,12 +85,12 @@ RA_IVAR                           float32     deg**-2            Right ascension
 DEC_IVAR                          float32     deg**-2            Declination inverse variance
 MORPHTYPE                         char[4]                        `Morphological Model`_ type
 MASKBITS                          int16                          Bitmask for ``coadd/*/*/*maskbits*`` maps, as on the `LS DR9 bitmasks page`_
-FLUX_G                            float32     nanomaggies        `LS`_ flux from tractor input (g)
-FLUX_R                            float32     nanomaggies        `LS`_ flux from tractor input (r)
-FLUX_Z                            float32     nanomaggies        `LS`_ flux from tractor input (z)
-FLUX_IVAR_G                       float32     nanomaggies**-2    Inverse Variance of FLUX_G
-FLUX_IVAR_R                       float32     nanomaggies**-2    Inverse Variance of FLUX_R
-FLUX_IVAR_Z                       float32     nanomaggies**-2    Inverse Variance of FLUX_Z
+FLUX_G                            float32     nanomaggy          `LS`_ flux from tractor input (g)
+FLUX_R                            float32     nanomaggy          `LS`_ flux from tractor input (r)
+FLUX_Z                            float32     nanomaggy          `LS`_ flux from tractor input (z)
+FLUX_IVAR_G                       float32     nanomaggy**-2      Inverse Variance of FLUX_G
+FLUX_IVAR_R                       float32     nanomaggy**-2      Inverse Variance of FLUX_R
+FLUX_IVAR_Z                       float32     nanomaggy**-2      Inverse Variance of FLUX_Z
 REF_ID                            int64                          Tyc1*1,000,000+Tyc2*10+Tyc3 for `Tycho-2`_; "sourceid" for `Gaia`_ DR2
 REF_CAT                           char[2]                        Reference catalog source for star: "T2" for `Tycho-2`_, "G2" for `Gaia`_ DR2, "L2" for the `SGA`_, empty otherwise
 REF_EPOCH                         float32     yr                 Reference epoch for Gaia/Tycho astrometry. Typically 2015.5 for Gaia.
@@ -129,7 +129,7 @@ Notes
 Some units in this file do not conform to the FITS standard:
 
 * deg^-2 is incorrectly recorded as 1/deg^2
-* nanomaggies^-2 is incorrectly recorded as 1/nanomaggy^2
+* nanomaggy^-2 is incorrectly recorded as 1/nanomaggy^2
 * mas^-2 is incorrectly recorded as 1/mas^2
 
 Such issues can typically be fixed by parsing the unit through astropy after reading in a Table, e.g.:

--- a/doc/DESI_TARGET/TARG_DIR/DR/VERSION/randoms/RESOLVE/randoms-allsky-seed-iteration.rst
+++ b/doc/DESI_TARGET/TARG_DIR/DR/VERSION/randoms/RESOLVE/randoms-allsky-seed-iteration.rst
@@ -100,12 +100,12 @@ PSFDEPTH_W2   float32                 PSF-based depth in WISE W2 (AB mag system)
 PSFSIZE_G     float32  arcsec         Weighted average PSF FWHM in `LS`_ g
 PSFSIZE_R     float32  arcsec         Weighted average PSF FWHM in `LS`_ r
 PSFSIZE_Z     float32  arcsec         Weighted average PSF FWHM in `LS`_ z
-APFLUX_G      float32  nanomaggies    Total flux extracted in a 0.75 arcsec radius in g
-APFLUX_R      float32  nanomaggies    Total flux extracted in a 0.75 arcsec radius in r
-APFLUX_Z      float32  nanomaggies    Total flux extracted in a 0.75 arcsec radius in z
-APFLUX_IVAR_G float32  nanomaggies^-2 Inverse variance of APFLUX_G
-APFLUX_IVAR_R float32  nanomaggies^-2 Inverse variance of APFLUX_R
-APFLUX_IVAR_Z float32  nanomaggies^-2 Inverse variance of APFLUX_Z
+APFLUX_G      float32  nanomaggy      Total flux extracted in a 0.75 arcsec radius in g
+APFLUX_R      float32  nanomaggy      Total flux extracted in a 0.75 arcsec radius in r
+APFLUX_Z      float32  nanomaggy      Total flux extracted in a 0.75 arcsec radius in z
+APFLUX_IVAR_G float32  nanomaggy^-2   Inverse variance of APFLUX_G
+APFLUX_IVAR_R float32  nanomaggy^-2   Inverse variance of APFLUX_R
+APFLUX_IVAR_Z float32  nanomaggy^-2   Inverse variance of APFLUX_Z
 MASKBITS      int16                   Bit mask of possible problems with pixel (see the LS `DR9 bitmasks page`_)
 WISEMASK_W1   uint8                   Bitwise mask for WISE W1 data (see the LS `DR9 bitmasks page`_)
 WISEMASK_W2   uint8                   Bitwise mask for WISE W2 data (see the LS `DR9 bitmasks page`_)

--- a/doc/DESI_TARGET/TARG_DIR/DR/VERSION/randoms/RESOLVE/randoms-seed-iteration.rst
+++ b/doc/DESI_TARGET/TARG_DIR/DR/VERSION/randoms/RESOLVE/randoms-seed-iteration.rst
@@ -99,12 +99,12 @@ PSFDEPTH_W2   float32                 PSF-based depth in WISE W2 (AB mag system)
 PSFSIZE_G     float32  arcsec         Weighted average PSF FWHM in `LS`_ g
 PSFSIZE_R     float32  arcsec         Weighted average PSF FWHM in `LS`_ r
 PSFSIZE_Z     float32  arcsec         Weighted average PSF FWHM in `LS`_ z
-APFLUX_G      float32  nanomaggies    Total flux extracted in a 0.75 arcsec radius in g
-APFLUX_R      float32  nanomaggies    Total flux extracted in a 0.75 arcsec radius in r
-APFLUX_Z      float32  nanomaggies    Total flux extracted in a 0.75 arcsec radius in z
-APFLUX_IVAR_G float32  nanomaggies^-2 Inverse variance of APFLUX_G
-APFLUX_IVAR_R float32  nanomaggies^-2 Inverse variance of APFLUX_R
-APFLUX_IVAR_Z float32  nanomaggies^-2 Inverse variance of APFLUX_Z
+APFLUX_G      float32  nanomaggy      Total flux extracted in a 0.75 arcsec radius in g
+APFLUX_R      float32  nanomaggy      Total flux extracted in a 0.75 arcsec radius in r
+APFLUX_Z      float32  nanomaggy      Total flux extracted in a 0.75 arcsec radius in z
+APFLUX_IVAR_G float32  nanomaggy^-2   Inverse variance of APFLUX_G
+APFLUX_IVAR_R float32  nanomaggy^-2   Inverse variance of APFLUX_R
+APFLUX_IVAR_Z float32  nanomaggy^-2   Inverse variance of APFLUX_Z
 MASKBITS      int16                   Bit mask of possible problems with pixel (see the LS `DR9 bitmasks page`_)
 WISEMASK_W1   uint8                   Bitwise mask for WISE W1 data (see the LS `DR9 bitmasks page`_)
 WISEMASK_W2   uint8                   Bitwise mask for WISE W2 data (see the LS `DR9 bitmasks page`_)

--- a/doc/DESI_TARGET/TARG_DIR/DR/VERSION/targets/PHASE/RESOLVE/OBSCON/PHASEtargets-OBSCON-RESOLVE-hp-HP.rst
+++ b/doc/DESI_TARGET/TARG_DIR/DR/VERSION/targets/PHASE/RESOLVE/OBSCON/PHASEtargets-OBSCON-RESOLVE-hp-HP.rst
@@ -105,12 +105,12 @@ DEC                               float64     deg                   Declination
 DEC_IVAR                          float32     deg^-2                Declination inverse variance
 DCHISQ                            float32[5]                        Difference in chi-squared between model fits
 EBV                               float32     mag                   Galactic extinction E(B-V) reddening from `SFD98`_
-FLUX_G                            float32     nanomaggies           `LS`_ flux from tractor input (g)
-FLUX_R                            float32     nanomaggies           `LS`_ flux from tractor input (r)
-FLUX_Z                            float32     nanomaggies           `LS`_ flux from tractor input (z)
-FLUX_IVAR_G                       float32     nanomaggies^-2        Inverse Variance of FLUX_G
-FLUX_IVAR_R                       float32     nanomaggies^-2        Inverse Variance of FLUX_R
-FLUX_IVAR_Z                       float32     nanomaggies^-2        Inverse Variance of FLUX_Z
+FLUX_G                            float32     nanomaggy             `LS`_ flux from tractor input (g)
+FLUX_R                            float32     nanomaggy             `LS`_ flux from tractor input (r)
+FLUX_Z                            float32     nanomaggy             `LS`_ flux from tractor input (z)
+FLUX_IVAR_G                       float32     nanomaggy^-2          Inverse Variance of FLUX_G
+FLUX_IVAR_R                       float32     nanomaggy^-2          Inverse Variance of FLUX_R
+FLUX_IVAR_Z                       float32     nanomaggy^-2          Inverse Variance of FLUX_Z
 MW_TRANSMISSION_G                 float32                           Milky Way dust transmission in `LS`_ g
 MW_TRANSMISSION_R                 float32                           Milky Way dust transmission in `LS`_ r
 MW_TRANSMISSION_Z                 float32                           Milky Way dust transmission in `LS`_ z
@@ -126,20 +126,20 @@ FRACIN_Z                          float32                           Fraction of 
 NOBS_G                            int16                             Number of images for central pixel in `LS`_ g
 NOBS_R                            int16                             Number of images for central pixel in `LS`_ r
 NOBS_Z                            int16                             Number of images for central pixel in `LS`_ z
-PSFDEPTH_G                        float32     nanomaggies^-2        PSF-based depth in `LS`_ g
-PSFDEPTH_R                        float32     nanomaggies^-2        PSF-based depth in `LS`_ r
-PSFDEPTH_Z                        float32     nanomaggies^-2        PSF-based depth in `LS`_ z
-GALDEPTH_G                        float32     nanomaggies^-2        Galaxy model-based depth in `LS`_ g
-GALDEPTH_R                        float32     nanomaggies^-2        Galaxy model-based depth in `LS`_ r
-GALDEPTH_Z                        float32     nanomaggies^-2        Galaxy model-based depth in `LS`_ z
-FLUX_W1                           float32     nanomaggies           WISE flux in W1 (AB system)
-FLUX_W2                           float32     nanomaggies           WISE flux in W2 (AB)
-FLUX_W3                           float32     nanomaggies           WISE flux in W3 (AB)
-FLUX_W4                           float32     nanomaggies           WISE flux in W4 (AB)
-FLUX_IVAR_W1                      float32     nanomaggies^-2        Inverse Variance of FLUX_W1 (AB system)
-FLUX_IVAR_W2                      float32     nanomaggies^-2        Inverse Variance of FLUX_W2 (AB)
-FLUX_IVAR_W3                      float32     nanomaggies^-2        Inverse Variance of FLUX_W3 (AB)
-FLUX_IVAR_W4                      float32     nanomaggies^-2        Inverse Variance of FLUX_W4 (AB)
+PSFDEPTH_G                        float32     nanomaggy^-2          PSF-based depth in `LS`_ g
+PSFDEPTH_R                        float32     nanomaggy^-2          PSF-based depth in `LS`_ r
+PSFDEPTH_Z                        float32     nanomaggy^-2          PSF-based depth in `LS`_ z
+GALDEPTH_G                        float32     nanomaggy^-2          Galaxy model-based depth in `LS`_ g
+GALDEPTH_R                        float32     nanomaggy^-2          Galaxy model-based depth in `LS`_ r
+GALDEPTH_Z                        float32     nanomaggy^-2          Galaxy model-based depth in `LS`_ z
+FLUX_W1                           float32     nanomaggy             WISE flux in W1 (AB system)
+FLUX_W2                           float32     nanomaggy             WISE flux in W2 (AB)
+FLUX_W3                           float32     nanomaggy             WISE flux in W3 (AB)
+FLUX_W4                           float32     nanomaggy             WISE flux in W4 (AB)
+FLUX_IVAR_W1                      float32     nanomaggy^-2          Inverse Variance of FLUX_W1 (AB system)
+FLUX_IVAR_W2                      float32     nanomaggy^-2          Inverse Variance of FLUX_W2 (AB)
+FLUX_IVAR_W3                      float32     nanomaggy^-2          Inverse Variance of FLUX_W3 (AB)
+FLUX_IVAR_W4                      float32     nanomaggy^-2          Inverse Variance of FLUX_W4 (AB)
 MW_TRANSMISSION_W1                float32                           Milky Way dust transmission in WISE W1
 MW_TRANSMISSION_W2                float32                           Milky Way dust transmission in WISE W2
 MW_TRANSMISSION_W3                float32                           Milky Way dust transmission in WISE W3
@@ -147,20 +147,20 @@ MW_TRANSMISSION_W4                float32                           Milky Way du
 ALLMASK_G                         int16                             Bitwise mask for central pixel in `LS`_ g
 ALLMASK_R                         int16                             Bitwise mask for central pixel in `LS`_ r
 ALLMASK_Z                         int16                             Bitwise mask for central pixel in `LS`_ z
-FIBERFLUX_G                       float32     nanomaggies           g-band object model flux for 1 arcsec seeing and 1.5 arcsec diameter fiber
-FIBERFLUX_R                       float32     nanomaggies           r-band object model flux for 1 arcsec seeing and 1.5 arcsec diameter fiber
-FIBERFLUX_Z                       float32     nanomaggies           z-band object model flux for 1 arcsec seeing and 1.5 arcsec diameter fiber
-FIBERTOTFLUX_G                    float32     nanomaggies           like FIBERFLUX_G but including all objects overlapping this location
-FIBERTOTFLUX_R                    float32     nanomaggies           like FIBERFLUX_R but including all objects overlapping this location
-FIBERTOTFLUX_Z                    float32     nanomaggies           like FIBERFLUX_Z but including all objects overlapping this location
+FIBERFLUX_G                       float32     nanomaggy             g-band object model flux for 1 arcsec seeing and 1.5 arcsec diameter fiber
+FIBERFLUX_R                       float32     nanomaggy             r-band object model flux for 1 arcsec seeing and 1.5 arcsec diameter fiber
+FIBERFLUX_Z                       float32     nanomaggy             z-band object model flux for 1 arcsec seeing and 1.5 arcsec diameter fiber
+FIBERTOTFLUX_G                    float32     nanomaggy             like FIBERFLUX_G but including all objects overlapping this location
+FIBERTOTFLUX_R                    float32     nanomaggy             like FIBERFLUX_R but including all objects overlapping this location
+FIBERTOTFLUX_Z                    float32     nanomaggy             like FIBERFLUX_Z but including all objects overlapping this location
 REF_EPOCH                         float32     yr                    reference epoch for Gaia/Tycho astrometry. Typically 2015.5 for Gaia.
 WISEMASK_W1                       byte                              W1 bitmask as cataloged on the `LS DR9 bitmasks page`_
 WISEMASK_W2                       byte                              W2 bitmask as cataloged on the `LS DR9 bitmasks page`_
 MASKBITS                          int16                             bitmask for ``coadd/*/*/*maskbits*`` maps, as on the `LS DR9 bitmasks page`_
-LC_FLUX_W1                        float32[15] nanomaggies           FLUX_W1 in each of up to fifteen unWISE coadd epochs (AB system; defaults to zero for unused entries)
-LC_FLUX_W2                        float32[15] nanomaggies           FLUX_W2 in each of up to fifteen unWISE coadd epochs (AB system; defaults to zero for unused entries)
-LC_FLUX_IVAR_W1                   float32[15] nanomaggies^-2        Inverse variance of LC_FLUX_W1 (AB system; defaults to zero for unused entries)
-LC_FLUX_IVAR_W2                   float32[15] nanomaggies^-2        Inverse variance of LC_FLUX_W2 (AB system; defaults to zero for unused entries)
+LC_FLUX_W1                        float32[15] nanomaggy             FLUX_W1 in each of up to fifteen unWISE coadd epochs (AB system; defaults to zero for unused entries)
+LC_FLUX_W2                        float32[15] nanomaggy             FLUX_W2 in each of up to fifteen unWISE coadd epochs (AB system; defaults to zero for unused entries)
+LC_FLUX_IVAR_W1                   float32[15] nanomaggy^-2          Inverse variance of LC_FLUX_W1 (AB system; defaults to zero for unused entries)
+LC_FLUX_IVAR_W2                   float32[15] nanomaggy^-2          Inverse variance of LC_FLUX_W2 (AB system; defaults to zero for unused entries)
 LC_NOBS_W1                        int16[15]                         NOBS_W1 in each of up to fifteen unWISE coadd epochs
 LC_NOBS_W2                        int16[15]                         NOBS_W2 in each of up to fifteen unWISE coadd epochs
 LC_MJD_W1                         float64[15]                       MJD_W1 in each of up to fifteen unWISE coadd epochs (defaults to zero for unused entries)
@@ -257,7 +257,7 @@ Notes
 Some units in this file do not conform to the FITS standard:
 
 * deg^-2 is incorrectly recorded as 1/deg^2
-* nanomaggies^-2 is incorrectly recorded as 1/nanomaggy^2
+* nanomaggy^-2 is incorrectly recorded as 1/nanomaggy^2
 * arcsec^-2 is incorrectly recorded as 1/arcsec^2
 * mas^-2 is incorrectly recorded as 1/mas^2
 

--- a/doc/DESI_TARGET/TARG_DIR/DR/VERSION/targets/PHASE/RESOLVE/OBSCON/targets-OBSCON-secondary.rst
+++ b/doc/DESI_TARGET/TARG_DIR/DR/VERSION/targets/PHASE/RESOLVE/OBSCON/targets-OBSCON-secondary.rst
@@ -76,9 +76,9 @@ PMRA                            float32     mas/yr           Reference catalog p
 PMDEC                           float32     mas/yr           Reference catalog proper motion in the Dec direction
 REF_EPOCH                       float32     yr               Reference epoch for Gaia/Tycho astrometry. Typically 2015.5 for Gaia.
 OVERRIDE                        bool                         ``True`` if the secondary target class was not matched to primary targets
-FLUX_G                          float32     nanomaggies      `LS`_ flux from tractor input (g)
-FLUX_R                          float32     nanomaggies      `LS`_ flux from tractor input (r)
-FLUX_Z                          float32     nanomaggies      `LS`_ flux from tractor input (z)
+FLUX_G                          float32     nanomaggy        `LS`_ flux from tractor input (g)
+FLUX_R                          float32     nanomaggy        `LS`_ flux from tractor input (r)
+FLUX_Z                          float32     nanomaggy        `LS`_ flux from tractor input (z)
 PARALLAX                        float32     mas              Reference catalog parallax
 GAIA_PHOT_G_MEAN_MAG            float32     mag              `Gaia`_ G band magnitude
 GAIA_PHOT_BP_MEAN_MAG           float32     mag              `Gaia`_ BP band magnitude

--- a/doc/DESI_TARGET/TARG_DIR/DR/VERSION/targets/PHASE/RESOLVE/OBSCON/targets-dr8.rst
+++ b/doc/DESI_TARGET/TARG_DIR/DR/VERSION/targets/PHASE/RESOLVE/OBSCON/targets-dr8.rst
@@ -103,12 +103,12 @@ DEC                               float64    deg                   Declination [
 DEC_IVAR                          float32    deg**-2               Declination inverse variance [1/degrees**2]
 DCHISQ                            float32[5]                       Difference in chi-squared between model fits
 EBV                               float32    mag                   Galactic extinction E(B-V) reddening from `SFD98`_
-FLUX_G                            float32    nanomaggies           `LS`_ flux from tractor input (g)
-FLUX_R                            float32    nanomaggies           `LS`_ flux from tractor input (r)
-FLUX_Z                            float32    nanomaggies           `LS`_ flux from tractor input (z)
-FLUX_IVAR_G                       float32    nanomaggies**-2       Inverse Variance of FLUX_G
-FLUX_IVAR_R                       float32    nanomaggies**-2       Inverse Variance of FLUX_R
-FLUX_IVAR_Z                       float32    nanomaggies**-2       Inverse Variance of FLUX_Z
+FLUX_G                            float32    nanomaggy             `LS`_ flux from tractor input (g)
+FLUX_R                            float32    nanomaggy             `LS`_ flux from tractor input (r)
+FLUX_Z                            float32    nanomaggy             `LS`_ flux from tractor input (z)
+FLUX_IVAR_G                       float32    nanomaggy**-2         Inverse Variance of FLUX_G
+FLUX_IVAR_R                       float32    nanomaggy**-2         Inverse Variance of FLUX_R
+FLUX_IVAR_Z                       float32    nanomaggy**-2         Inverse Variance of FLUX_Z
 MW_TRANSMISSION_G                 float32                          Milky Way dust transmission in `LS`_ g
 MW_TRANSMISSION_R                 float32                          Milky Way dust transmission in `LS`_ r
 MW_TRANSMISSION_Z                 float32                          Milky Way dust transmission in `LS`_ z
@@ -124,20 +124,20 @@ FRACIN_Z                          float32                          Fraction of a
 NOBS_G                            int16                            Number of images for central pixel in `LS`_ g
 NOBS_R                            int16                            Number of images for central pixel in `LS`_ r
 NOBS_Z                            int16                            Number of images for central pixel in `LS`_ z
-PSFDEPTH_G                        float32    nanomaggies**-2       PSF-based depth in `LS`_ g
-PSFDEPTH_R                        float32    nanomaggies**-2       PSF-based depth in `LS`_ r
-PSFDEPTH_Z                        float32    nanomaggies**-2       PSF-based depth in `LS`_ z
-GALDEPTH_G                        float32    nanomaggies**-2       Galaxy model-based depth in `LS`_ g
-GALDEPTH_R                        float32    nanomaggies**-2       Galaxy model-based depth in `LS`_ r
-GALDEPTH_Z                        float32    nanomaggies**-2       Galaxy model-based depth in `LS`_ z
-FLUX_W1                           float32    nanomaggies           WISE flux in W1 (AB system)
-FLUX_W2                           float32    nanomaggies           WISE flux in W2 (AB)
-FLUX_W3                           float32    nanomaggies           WISE flux in W3 (AB)
-FLUX_W4                           float32    nanomaggies           WISE flux in W4 (AB)
-FLUX_IVAR_W1                      float32    nanomaggies**-2       Inverse Variance of FLUX_W1 (AB system)
-FLUX_IVAR_W2                      float32    nanomaggies**-2       Inverse Variance of FLUX_W2 (AB)
-FLUX_IVAR_W3                      float32    nanomaggies**-2       Inverse Variance of FLUX_W3 (AB)
-FLUX_IVAR_W4                      float32    nanomaggies**-2       Inverse Variance of FLUX_W4 (AB)
+PSFDEPTH_G                        float32    nanomaggy**-2         PSF-based depth in `LS`_ g
+PSFDEPTH_R                        float32    nanomaggy**-2         PSF-based depth in `LS`_ r
+PSFDEPTH_Z                        float32    nanomaggy**-2         PSF-based depth in `LS`_ z
+GALDEPTH_G                        float32    nanomaggy**-2         Galaxy model-based depth in `LS`_ g
+GALDEPTH_R                        float32    nanomaggy**-2         Galaxy model-based depth in `LS`_ r
+GALDEPTH_Z                        float32    nanomaggy**-2         Galaxy model-based depth in `LS`_ z
+FLUX_W1                           float32    nanomaggy             WISE flux in W1 (AB system)
+FLUX_W2                           float32    nanomaggy             WISE flux in W2 (AB)
+FLUX_W3                           float32    nanomaggy             WISE flux in W3 (AB)
+FLUX_W4                           float32    nanomaggy             WISE flux in W4 (AB)
+FLUX_IVAR_W1                      float32    nanomaggy**-2         Inverse Variance of FLUX_W1 (AB system)
+FLUX_IVAR_W2                      float32    nanomaggy**-2         Inverse Variance of FLUX_W2 (AB)
+FLUX_IVAR_W3                      float32    nanomaggy**-2         Inverse Variance of FLUX_W3 (AB)
+FLUX_IVAR_W4                      float32    nanomaggy**-2         Inverse Variance of FLUX_W4 (AB)
 MW_TRANSMISSION_W1                float32                          Milky Way dust transmission in WISE W1
 MW_TRANSMISSION_W2                float32                          Milky Way dust transmission in WISE W2
 MW_TRANSMISSION_W3                float32                          Milky Way dust transmission in WISE W3
@@ -145,12 +145,12 @@ MW_TRANSMISSION_W4                float32                          Milky Way dus
 ALLMASK_G                         int16                            Bitwise mask for central pixel in `LS`_ g
 ALLMASK_R                         int16                            Bitwise mask for central pixel in `LS`_ r
 ALLMASK_Z                         int16                            Bitwise mask for central pixel in `LS`_ z
-FIBERFLUX_G                       float32    nanomaggies           g-band object model flux for 1 arcsec seeing and 1.5 arcsec diameter fiber
-FIBERFLUX_R                       float32    nanomaggies           r-band object model flux for 1 arcsec seeing and 1.5 arcsec diameter fiber
-FIBERFLUX_Z                       float32    nanomaggies           z-band object model flux for 1 arcsec seeing and 1.5 arcsec diameter fiber
-FIBERTOTFLUX_G                    float32    nanomaggies           like FIBERFLUX_G but including all objects overlapping this location
-FIBERTOTFLUX_R                    float32    nanomaggies           like FIBERFLUX_R but including all objects overlapping this location
-FIBERTOTFLUX_Z                    float32    nanomaggies           like FIBERFLUX_Z but including all objects overlapping this location
+FIBERFLUX_G                       float32    nanomaggy             g-band object model flux for 1 arcsec seeing and 1.5 arcsec diameter fiber
+FIBERFLUX_R                       float32    nanomaggy             r-band object model flux for 1 arcsec seeing and 1.5 arcsec diameter fiber
+FIBERFLUX_Z                       float32    nanomaggy             z-band object model flux for 1 arcsec seeing and 1.5 arcsec diameter fiber
+FIBERTOTFLUX_G                    float32    nanomaggy             like FIBERFLUX_G but including all objects overlapping this location
+FIBERTOTFLUX_R                    float32    nanomaggy             like FIBERFLUX_R but including all objects overlapping this location
+FIBERTOTFLUX_Z                    float32    nanomaggy             like FIBERFLUX_Z but including all objects overlapping this location
 REF_EPOCH                         float32    yr                    reference epoch for Gaia/Tycho astrometry. Typically 2015.5 for Gaia.
 WISEMASK_W1                       byte                             W1 bitmask as cataloged on the `LS DR8 bitmasks page`_
 WISEMASK_W2                       byte                             W2 bitmask as cataloged on the `LS DR8 bitmasks page`_

--- a/doc/DESI_TARGET/TARG_DIR/gaiadr2/VERSION/targets/PHASE/RESOLVE/BACKUP/PHASEtargets-BACKUP-hp-HP.rst
+++ b/doc/DESI_TARGET/TARG_DIR/gaiadr2/VERSION/targets/PHASE/RESOLVE/BACKUP/PHASEtargets-BACKUP-hp-HP.rst
@@ -104,12 +104,12 @@ DEC                               float64     deg                   Declination 
 DEC_IVAR                          float32     deg^-2                Declination inverse variance
 DCHISQ                            float32[5]                        Difference in chi-squared between model fits
 EBV                               float32     mag                   Galactic extinction E(B-V) reddening from `SFD98`_
-FLUX_G                            float32     nanomaggies           `LS`_ flux from tractor input (g)
-FLUX_R                            float32     nanomaggies           `LS`_ flux from tractor input (r)
-FLUX_Z                            float32     nanomaggies           `LS`_ flux from tractor input (z)
-FLUX_IVAR_G                       float32     nanomaggies^-2        Inverse Variance of FLUX_G
-FLUX_IVAR_R                       float32     nanomaggies^-2        Inverse Variance of FLUX_R
-FLUX_IVAR_Z                       float32     nanomaggies^-2        Inverse Variance of FLUX_Z
+FLUX_G                            float32     nanomaggy             `LS`_ flux from tractor input (g)
+FLUX_R                            float32     nanomaggy             `LS`_ flux from tractor input (r)
+FLUX_Z                            float32     nanomaggy             `LS`_ flux from tractor input (z)
+FLUX_IVAR_G                       float32     nanomaggy^-2          Inverse Variance of FLUX_G
+FLUX_IVAR_R                       float32     nanomaggy^-2          Inverse Variance of FLUX_R
+FLUX_IVAR_Z                       float32     nanomaggy^-2          Inverse Variance of FLUX_Z
 MW_TRANSMISSION_G                 float32                           Milky Way dust transmission in `LS`_ g
 MW_TRANSMISSION_R                 float32                           Milky Way dust transmission in `LS`_ r
 MW_TRANSMISSION_Z                 float32                           Milky Way dust transmission in `LS`_ z
@@ -125,20 +125,20 @@ FRACIN_Z                          float32                           Fraction of 
 NOBS_G                            int16                             Number of images for central pixel in `LS`_ g
 NOBS_R                            int16                             Number of images for central pixel in `LS`_ r
 NOBS_Z                            int16                             Number of images for central pixel in `LS`_ z
-PSFDEPTH_G                        float32     nanomaggies^-2        PSF-based depth in `LS`_ g
-PSFDEPTH_R                        float32     nanomaggies^-2        PSF-based depth in `LS`_ r
-PSFDEPTH_Z                        float32     nanomaggies^-2        PSF-based depth in `LS`_ z
-GALDEPTH_G                        float32     nanomaggies^-2        Galaxy model-based depth in `LS`_ g
-GALDEPTH_R                        float32     nanomaggies^-2        Galaxy model-based depth in `LS`_ r
-GALDEPTH_Z                        float32     nanomaggies^-2        Galaxy model-based depth in `LS`_ z
-FLUX_W1                           float32     nanomaggies           WISE flux in W1 (AB system)
-FLUX_W2                           float32     nanomaggies           WISE flux in W2 (AB)
-FLUX_W3                           float32     nanomaggies           WISE flux in W3 (AB)
-FLUX_W4                           float32     nanomaggies           WISE flux in W4 (AB)
-FLUX_IVAR_W1                      float32     nanomaggies^-2        Inverse Variance of FLUX_W1 (AB system)
-FLUX_IVAR_W2                      float32     nanomaggies^-2        Inverse Variance of FLUX_W2 (AB)
-FLUX_IVAR_W3                      float32     nanomaggies^-2        Inverse Variance of FLUX_W3 (AB)
-FLUX_IVAR_W4                      float32     nanomaggies^-2        Inverse Variance of FLUX_W4 (AB)
+PSFDEPTH_G                        float32     nanomaggy^-2          PSF-based depth in `LS`_ g
+PSFDEPTH_R                        float32     nanomaggy^-2          PSF-based depth in `LS`_ r
+PSFDEPTH_Z                        float32     nanomaggy^-2          PSF-based depth in `LS`_ z
+GALDEPTH_G                        float32     nanomaggy^-2          Galaxy model-based depth in `LS`_ g
+GALDEPTH_R                        float32     nanomaggy^-2          Galaxy model-based depth in `LS`_ r
+GALDEPTH_Z                        float32     nanomaggy^-2          Galaxy model-based depth in `LS`_ z
+FLUX_W1                           float32     nanomaggy             WISE flux in W1 (AB system)
+FLUX_W2                           float32     nanomaggy             WISE flux in W2 (AB)
+FLUX_W3                           float32     nanomaggy             WISE flux in W3 (AB)
+FLUX_W4                           float32     nanomaggy             WISE flux in W4 (AB)
+FLUX_IVAR_W1                      float32     nanomaggy^-2          Inverse Variance of FLUX_W1 (AB system)
+FLUX_IVAR_W2                      float32     nanomaggy^-2          Inverse Variance of FLUX_W2 (AB)
+FLUX_IVAR_W3                      float32     nanomaggy^-2          Inverse Variance of FLUX_W3 (AB)
+FLUX_IVAR_W4                      float32     nanomaggy^-2          Inverse Variance of FLUX_W4 (AB)
 MW_TRANSMISSION_W1                float32                           Milky Way dust transmission in WISE W1
 MW_TRANSMISSION_W2                float32                           Milky Way dust transmission in WISE W2
 MW_TRANSMISSION_W3                float32                           Milky Way dust transmission in WISE W3
@@ -146,20 +146,20 @@ MW_TRANSMISSION_W4                float32                           Milky Way du
 ALLMASK_G                         int16                             Bitwise mask for central pixel in `LS`_ g
 ALLMASK_R                         int16                             Bitwise mask for central pixel in `LS`_ r
 ALLMASK_Z                         int16                             Bitwise mask for central pixel in `LS`_ z
-FIBERFLUX_G                       float32     nanomaggies           g-band object model flux for 1 arcsec seeing and 1.5 arcsec diameter fiber
-FIBERFLUX_R                       float32     nanomaggies           r-band object model flux for 1 arcsec seeing and 1.5 arcsec diameter fiber
-FIBERFLUX_Z                       float32     nanomaggies           z-band object model flux for 1 arcsec seeing and 1.5 arcsec diameter fiber
-FIBERTOTFLUX_G                    float32     nanomaggies           like FIBERFLUX_G but including all objects overlapping this location
-FIBERTOTFLUX_R                    float32     nanomaggies           like FIBERFLUX_R but including all objects overlapping this location
-FIBERTOTFLUX_Z                    float32     nanomaggies           like FIBERFLUX_Z but including all objects overlapping this location
+FIBERFLUX_G                       float32     nanomaggy             g-band object model flux for 1 arcsec seeing and 1.5 arcsec diameter fiber
+FIBERFLUX_R                       float32     nanomaggy             r-band object model flux for 1 arcsec seeing and 1.5 arcsec diameter fiber
+FIBERFLUX_Z                       float32     nanomaggy             z-band object model flux for 1 arcsec seeing and 1.5 arcsec diameter fiber
+FIBERTOTFLUX_G                    float32     nanomaggy             like FIBERFLUX_G but including all objects overlapping this location
+FIBERTOTFLUX_R                    float32     nanomaggy             like FIBERFLUX_R but including all objects overlapping this location
+FIBERTOTFLUX_Z                    float32     nanomaggy             like FIBERFLUX_Z but including all objects overlapping this location
 REF_EPOCH                         float32     yr                    reference epoch for Gaia/Tycho astrometry. Typically 2015.5 for Gaia.
 WISEMASK_W1                       byte                              W1 bitmask as cataloged on the `LS DR9 bitmasks page`_
 WISEMASK_W2                       byte                              W2 bitmask as cataloged on the `LS DR9 bitmasks page`_
 MASKBITS                          int16                             bitmask for ``coadd/*/*/*maskbits*`` maps, as on the `LS DR9 bitmasks page`_
-LC_FLUX_W1                        float32[15] nanomaggies           FLUX_W1 in each of up to fifteen unWISE coadd epochs (AB system; defaults to zero for unused entries)
-LC_FLUX_W2                        float32[15] nanomaggies           FLUX_W2 in each of up to fifteen unWISE coadd epochs (AB system; defaults to zero for unused entries)
-LC_FLUX_IVAR_W1                   float32[15] nanomaggies^-2        Inverse variance of LC_FLUX_W1 (AB system; defaults to zero for unused entries)
-LC_FLUX_IVAR_W2                   float32[15] nanomaggies^-2        Inverse variance of LC_FLUX_W2 (AB system; defaults to zero for unused entries)
+LC_FLUX_W1                        float32[15] nanomaggy             FLUX_W1 in each of up to fifteen unWISE coadd epochs (AB system; defaults to zero for unused entries)
+LC_FLUX_W2                        float32[15] nanomaggy             FLUX_W2 in each of up to fifteen unWISE coadd epochs (AB system; defaults to zero for unused entries)
+LC_FLUX_IVAR_W1                   float32[15] nanomaggy^-2          Inverse variance of LC_FLUX_W1 (AB system; defaults to zero for unused entries)
+LC_FLUX_IVAR_W2                   float32[15] nanomaggy^-2          Inverse variance of LC_FLUX_W2 (AB system; defaults to zero for unused entries)
 LC_NOBS_W1                        int16[15]                         NOBS_W1 in each of up to fifteen unWISE coadd epochs
 LC_NOBS_W2                        int16[15]                         NOBS_W2 in each of up to fifteen unWISE coadd epochs
 LC_MJD_W1                         float64[15]                       MJD_W1 in each of up to fifteen unWISE coadd epochs (defaults to zero for unused entries)
@@ -254,7 +254,7 @@ Notes
 Some units in this file do not conform to the FITS standard:
 
 * deg^-2 is incorrectly recorded as 1/deg^2
-* nanomaggies^-2 is incorrectly recorded as 1/nanomaggy^2
+* nanomaggy^-2 is incorrectly recorded as 1/nanomaggy^2
 * arcsec^-2 is incorrectly recorded as 1/arcsec^2
 * mas^-2 is incorrectly recorded as 1/mas^2
 

--- a/doc/DESI_TARGET/fiberassign/tiles/TILES_VERSION/TILEXX/fiberassign-TILEID.rst
+++ b/doc/DESI_TARGET/fiberassign/tiles/TILES_VERSION/TILEXX/fiberassign-TILEID.rst
@@ -153,22 +153,22 @@ BRICKID               int32                  Imaging Surveys brick ID
 BRICK_OBJID           int32                  Imaging surveys OBJID on that brick
 MORPHTYPE             char[4]                Imaging surveys morphological type
 EBV                   float32 mag            Galactic extinction E(B-V) reddening
-FLUX_G                float32 nanomaggies    Flux in g-band
-FLUX_R                float32 nanomaggies    Flux in r-band
-FLUX_Z                float32 nanomaggies    Flux in z-band
-FLUX_W1               float32 nanomaggies    Flux in WISE W1-band
-FLUX_W2               float32 nanomaggies    Flux in WISE W2-band
-FLUX_IVAR_G           float32 nanomaggies^-2 Inverse variance of FLUX_G
-FLUX_IVAR_R           float32 nanomaggies^-2 Inverse variance of FLUX_R
-FLUX_IVAR_Z           float32 nanomaggies^-2 Inverse variance of FLUX_Z
-FLUX_IVAR_W1          float32 nanomaggies^-2 Inverse variance of FLUX_W1
-FLUX_IVAR_W2          float32 nanomaggies^-2 Inverse variance of FLUX_W2
-FIBERFLUX_G           float32 nanomaggies    g-band object model flux for 1 arcsec seeing and 1.5 arcsec diameter fiber
-FIBERFLUX_R           float32 nanomaggies    r-band object model flux for 1 arcsec seeing and 1.5 arcsec diameter fiber
-FIBERFLUX_Z           float32 nanomaggies    z-band object model flux for 1 arcsec seeing and 1.5 arcsec diameter fiber
-FIBERTOTFLUX_G        float32 nanomaggies    like FIBERFLUX_G but including all objects overlapping this location
-FIBERTOTFLUX_R        float32 nanomaggies    like FIBERFLUX_R but including all objects overlapping this location
-FIBERTOTFLUX_Z        float32 nanomaggies    like FIBERFLUX_Z but including all objects overlapping this location
+FLUX_G                float32 nanomaggy      Flux in g-band
+FLUX_R                float32 nanomaggy      Flux in r-band
+FLUX_Z                float32 nanomaggy      Flux in z-band
+FLUX_W1               float32 nanomaggy      Flux in WISE W1-band
+FLUX_W2               float32 nanomaggy      Flux in WISE W2-band
+FLUX_IVAR_G           float32 nanomaggy^-2   Inverse variance of FLUX_G
+FLUX_IVAR_R           float32 nanomaggy^-2   Inverse variance of FLUX_R
+FLUX_IVAR_Z           float32 nanomaggy^-2   Inverse variance of FLUX_Z
+FLUX_IVAR_W1          float32 nanomaggy^-2   Inverse variance of FLUX_W1
+FLUX_IVAR_W2          float32 nanomaggy^-2   Inverse variance of FLUX_W2
+FIBERFLUX_G           float32 nanomaggy      g-band object model flux for 1 arcsec seeing and 1.5 arcsec diameter fiber
+FIBERFLUX_R           float32 nanomaggy      r-band object model flux for 1 arcsec seeing and 1.5 arcsec diameter fiber
+FIBERFLUX_Z           float32 nanomaggy      z-band object model flux for 1 arcsec seeing and 1.5 arcsec diameter fiber
+FIBERTOTFLUX_G        float32 nanomaggy      like FIBERFLUX_G but including all objects overlapping this location
+FIBERTOTFLUX_R        float32 nanomaggy      like FIBERFLUX_R but including all objects overlapping this location
+FIBERTOTFLUX_Z        float32 nanomaggy      like FIBERFLUX_Z but including all objects overlapping this location
 MASKBITS              int16                  Bitwise mask from the imaging indicating potential issue or blending
 SERSIC                float32                Power-law index for the Sersic profile model
 SHAPE_R               float32 arcsec         Half-light radius of galaxy model for galaxy type
@@ -246,9 +246,9 @@ PETAL_LOC     int16               Petal location [0-9]
 DEVICE_LOC    int32               Device location on focal plane [0-523]
 PRIORITY      int32               Assignment priority; larger = higher priority
 SUBPRIORITY   float64             Assignment subpriority [0-1]
-FIBERFLUX_G   float32 nanomaggies Flux in g-band
-FIBERFLUX_R   float32 nanomaggies Flux in r-band
-FIBERFLUX_Z   float32 nanomaggies Flux in z-band
+FIBERFLUX_G   float32 nanomaggy   Flux in g-band
+FIBERFLUX_R   float32 nanomaggy   Flux in r-band
+FIBERFLUX_Z   float32 nanomaggy   Flux in z-band
 ============= ======= =========== ===================
 
 HDU3
@@ -299,12 +299,12 @@ TARGET_RA_IVAR                    float32 deg^-2         Inverse variance of TAR
 TARGET_DEC_IVAR                   float32 deg^-2         Inverse variance of TARGET_DEC
 MORPHTYPE                         char[4]                Imaging surveys morphological type
 MASKBITS                          int16                  Bitwise mask from the imaging indicating potential issue or blending
-FLUX_G                            float32 nanomaggies    Flux in g-band
-FLUX_R                            float32 nanomaggies    Flux in r-band
-FLUX_Z                            float32 nanomaggies    Flux in z-band
-FLUX_IVAR_G                       float32 nanomaggies^-2 Inverse variance of FLUX_G
-FLUX_IVAR_R                       float32 nanomaggies^-2 Inverse variance of FLUX_R
-FLUX_IVAR_Z                       float32 nanomaggies^-2 Inverse variance of FLUX_Z
+FLUX_G                            float32 nanomaggy      Flux in g-band
+FLUX_R                            float32 nanomaggy      Flux in r-band
+FLUX_Z                            float32 nanomaggy      Flux in z-band
+FLUX_IVAR_G                       float32 nanomaggy^-2   Inverse variance of FLUX_G
+FLUX_IVAR_R                       float32 nanomaggy^-2   Inverse variance of FLUX_R
+FLUX_IVAR_Z                       float32 nanomaggy^-2   Inverse variance of FLUX_Z
 REF_ID                            int64                  Astrometric catalog reference ID (SOURCE_ID from Gaia and SGA; built from TYC1, TYC2, TYC3 for Tycho2)
 REF_CAT                           char[2]                Reference catalog source for this star
 REF_EPOCH                         float32 yr             Reference catalog reference epoch


### PR DESCRIPTION
This PR alters uses of the unit "nanomaggies" to "nanomaggy" in targeting files (after checking that the relevant target-related files do, indeed, use "nanomaggy").

Updates have been made for two reasons:

- Files actually include the formal unit "nanomaggy."
- Or, files include no units, in which case "nanomaggy" is used for consistency.