### PR TITLE
tile-based spectra/redshift column updates

### DIFF
--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/tiles/GROUPTYPE/TILEID/GROUPID/coadd-SPECTROGRAPH-TILEID-GROUPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/tiles/GROUPTYPE/TILEID/GROUPID/coadd-SPECTROGRAPH-TILEID-GROUPID.rst
@@ -129,62 +129,62 @@ TODO: add units
 ========================== ======= ============ ===============================================================================================================================
 Name                       Type    Units        Description
 ========================== ======= ============ ===============================================================================================================================
-TARGETID                   int64                Unique target ID
+TARGETID                   int64                Unique DESI target ID
 PETAL_LOC                  int16                Petal location [0-9]
 DEVICE_LOC                 int32                Device location on focal plane [0-523]
-LOCATION                   int64                FP location PETAL_LOC*1000 + DEVICE_LOC
+LOCATION                   int64                Location on the focal plane PETAL_LOC*1000 + DEVICE_LOC
 FIBER                      int32                Fiber ID on the CCDs [0-4999]
-COADD_FIBERSTATUS          int32                Logical AND of FIBERSTATUS bitmasks from input fibermaps
-TARGET_RA                  float64 deg          Target Right Ascension [degrees]
-TARGET_DEC                 float64 deg          Target declination [degrees]
-PMRA                       float32 mas yr^-1    PM in +RA dir (already incl cos(dec))
-PMDEC                      float32 mas yr^-1    Proper motion in +dec direction
-REF_EPOCH                  float32 yr           proper motion reference epoch
-LAMBDA_REF                 float32              Wavelength at which fiber was centered
+COADD_FIBERSTATUS          int32                bitwise-AND of input FIBERSTATUS
+TARGET_RA                  float64 deg          Target right ascension
+TARGET_DEC                 float64 deg          Target declination
+PMRA                       float32 mas yr^-1    proper motion in the +RA direction (already including cos(dec))
+PMDEC                      float32 mas yr^-1    Proper motion in the +Dec direction
+REF_EPOCH                  float32 yr           Reference epoch for Gaia/Tycho astrometry. Typically 2015.5 for Gaia
+LAMBDA_REF                 float32 Angstrom     Requested wavelength at which targets should be centered on fibers
 FA_TARGET                  int64                Targeting bit internally used by fiberassign (linked with FA_TYPE)
-FA_TYPE                    binary               Internal fiberassign target type
-OBJTYPE                    char[3]              SKY, TGT, NON
-FIBERASSIGN_X              float32              Expected CS5 X on focal plane
-FIBERASSIGN_Y              float32              Expected CS5 Y on focal plane
-PRIORITY                   int32                Assignment priority; larger=higher priority
-SUBPRIORITY                float64              Assignment subpriority [0-1)
-OBSCONDITIONS              int32                bitmask of allowable observing conditions
-RELEASE                    int16                imaging surveys release ID
-BRICKID                    int32                Imaging Surveys brick ID
+FA_TYPE                    binary               Fiberassign internal target type (science, standard, sky, safe, suppsky)
+OBJTYPE                    char[3]              Object type: TGT, SKY, NON, BAD
+FIBERASSIGN_X              float32 mm           Fiberassign expected CS5 X location on focal plane
+FIBERASSIGN_Y              float32 mm           Fiberassign expected CS5 Y location on focal plane
+PRIORITY                   int32                Target current priority
+SUBPRIORITY                float64              Random subpriority [0-1) to break assignment ties
+OBSCONDITIONS              int32                Bitmask of allowed observing conditions
+RELEASE                    int16                Imaging surveys release ID
+BRICKID                    int32                Brick ID from tractor input
 BRICK_OBJID                int32                Imaging Surveys OBJID on that brick
-MORPHTYPE                  char[4]              Imaging Surveys morphological type
-FLUX_G                     float32 nanomaggy    g-band flux
-FLUX_R                     float32 nanomaggy    r-band flux
-FLUX_Z                     float32 nanomaggy    z-band flux
-FLUX_IVAR_G                float32 nanomaggy^-2 Inverse variance of FLUX_G
-FLUX_IVAR_R                float32 nanomaggy^-2 Inverse variance of FLUX_R
-FLUX_IVAR_Z                float32 nanomaggy^-2 Inverse variance of FLUX_Z
-MASKBITS                   int16                Photometry mask bits
-REF_ID                     int64                Astrometric cat refID (Gaia SOURCE_ID)
-REF_CAT                    char[2]              astrometry reference catalog
-GAIA_PHOT_G_MEAN_MAG       float32 mag          Gaia G band mag
-GAIA_PHOT_BP_MEAN_MAG      float32 mag          Gaia BP band mag
-GAIA_PHOT_RP_MEAN_MAG      float32 mag          Gaia RP band mag
-PARALLAX                   float32 mas          Parallax
-BRICKNAME                  char[8]              Imaging Surveys brick name
+MORPHTYPE                  char[4]              Imaging Surveys morphological type from Tractor
+FLUX_G                     float32 nanomaggy    Flux in the Legacy Survey g-band (AB)
+FLUX_R                     float32 nanomaggy    Flux in the Legacy Survey r-band (AB)
+FLUX_Z                     float32 nanomaggy    Flux in the Legacy Survey z-band (AB)
+FLUX_IVAR_G                float32 nanomaggy^-2 Inverse variance of FLUX_G (AB)
+FLUX_IVAR_R                float32 nanomaggy^-2 Inverse variance of FLUX_R (AB)
+FLUX_IVAR_Z                float32 nanomaggy^-2 Inverse variance of FLUX_Z (AB)
+MASKBITS                   int16                Bitwise mask from the imaging indicating potential issue or blending
+REF_ID                     int64                Tyc1*1,000,000+Tyc2*10+Tyc3 for Tycho-2; “sourceid” for Gaia DR2
+REF_CAT                    char[2]              Reference catalog source for star: “T2” for Tycho-2, “G2” for Gaia DR2, “L2” for the SGA, empty otherwise
+GAIA_PHOT_G_MEAN_MAG       float32 mag          Gaia G band magnitude
+GAIA_PHOT_BP_MEAN_MAG      float32 mag          Gaia BP band magnitude
+GAIA_PHOT_RP_MEAN_MAG      float32 mag          Gaia RP band magnitude
+PARALLAX                   float32 mas          Reference catalog parallax
+BRICKNAME                  char[8]              Brick name from tractor input
 EBV                        float32 mag          Galactic extinction E(B-V) reddening from SFD98
-FLUX_W1                    float32 nanomaggy    WISE W1-band flux
-FLUX_W2                    float32 nanomaggy    WISE W2-band flux
-FLUX_IVAR_W1               float32 nanomaggy^-2 Inverse variance of FLUX_W1
-FLUX_IVAR_W2               float32 nanomaggy^-2 Inverse variance of FLUX_W2
-FIBERFLUX_G                float32 nanomaggy    g-band model flux 1&quot; seeing, 1.5&quot; dia fiber
-FIBERFLUX_R                float32 nanomaggy    r-band model flux 1&quot; seeing, 1.5&quot; dia fiber
-FIBERFLUX_Z                float32 nanomaggy    z-band model flux 1&quot; seeing, 1.5&quot; dia fiber
-FIBERTOTFLUX_G             float32 nanomaggy    fiberflux model incl. all objs at this loc
-FIBERTOTFLUX_R             float32 nanomaggy    fiberflux model incl. all objs at this loc
-FIBERTOTFLUX_Z             float32 nanomaggy    fiberflux model incl. all objs at this loc
-SERSIC                     float32              Power-law index for the Sersic profile model
-SHAPE_R                    float32 arcsec       Half-light radius of galaxy model
-SHAPE_E1                   float32              Ellipticity component 1 for galaxy model
-SHAPE_E2                   float32              Ellipticity component 2 for galaxy model
-PHOTSYS                    char[1]              N for BASS/MzLS, S for DECam
-PRIORITY_INIT              int64                initial priority
-NUMOBS_INIT                int64                initial number of requested observations
+FLUX_W1                    float32 nanomaggy    WISE flux in W1 (AB)
+FLUX_W2                    float32 nanomaggy    WISE flux in W2 (AB)
+FLUX_IVAR_W1               float32 nanomaggy^-2 Inverse variance of FLUX_W1 (AB)
+FLUX_IVAR_W2               float32 nanomaggy^-2 Inverse variance of FLUX_W2 (AB)
+FIBERFLUX_G                float32 nanomaggy    Predicted g-band flux within a fiber of diameter 1.5 arcsec from this object in 1 arcsec Gaussian seeing
+FIBERFLUX_R                float32 nanomaggy    Predicted r-band flux within a fiber of diameter 1.5 arcsec from this object in 1 arcsec Gaussian seeing
+FIBERFLUX_Z                float32 nanomaggy    Predicted z-band flux within a fiber of diameter 1.5 arcsec from this object in 1 arcsec Gaussian seeing
+FIBERTOTFLUX_G             float32 nanomaggy    Predicted g-band flux within a fiber of diameter 1.5 arcsec from all sources at this location in 1 arcsec Gaussian seeing
+FIBERTOTFLUX_R             float32 nanomaggy    Predicted r-band flux within a fiber of diameter 1.5 arcsec from all sources at this location in 1 arcsec Gaussian seeing
+FIBERTOTFLUX_Z             float32 nanomaggy    Predicted z-band flux within a fiber of diameter 1.5 arcsec from all sources at this location in 1 arcsec Gaussian seeing
+SERSIC                     float32              Power-law index for the Sersic profile model (MORPHTYPE=”SER”)
+SHAPE_R                    float32 arcsec       Half-light radius of galaxy model (&gt;0)
+SHAPE_E1                   float32              Ellipticity component 1 of galaxy model for galaxy type MORPHTYPE
+SHAPE_E2                   float32              Ellipticity component 2 of galaxy model for galaxy type MORPHTYPE
+PHOTSYS                    char[1]              &#x27;N&#x27; for the MzLS/BASS photometric system, &#x27;S&#x27; for DECaLS
+PRIORITY_INIT              int64                Target initial priority from target selection bitmasks and OBSCONDITIONS
+NUMOBS_INIT                int64                Initial number of observations for target calculated across target selection bitmasks and OBSCONDITIONS
 SV1_DESI_TARGET [1]_       int64                DESI (dark time program) target selection bitmask for SV1
 SV1_BGS_TARGET [1]_        int64                BGS (bright time program) target selection bitmask for SV1
 SV1_MWS_TARGET [1]_        int64                MWS (bright time program) target selection bitmask for SV1
@@ -193,25 +193,25 @@ SV3_DESI_TARGET [1]_       int64                DESI (dark time program) target 
 SV3_BGS_TARGET [1]_        int64                BGS (bright time program) target selection bitmask for SV3
 SV3_MWS_TARGET [1]_        int64                MWS (bright time program) target selection bitmask for SV3
 SV3_SCND_TARGET [1]_       int64                Secondary target selection bitmask for SV3
-DESI_TARGET                int64                Dark survey + calibration targeting bits
-BGS_TARGET                 int64                Bright Galaxy Survey targeting bits
+DESI_TARGET                int64                DESI (dark time program) target selection bitmask
+BGS_TARGET                 int64                BGS (Bright Galaxy Survey) target selection bitmask
 MWS_TARGET                 int64                Milky Way Survey targeting bits
-SCND_TARGET [1]_           int64                Secondary targeting bits
-PLATE_RA                   float64 deg          Right Ascension for Platemaker to use [degrees]
-PLATE_DEC                  float64 deg          declination for Platemaker to use [degrees]
-TILEID                     int32                DESI tile ID
-COADD_NUMEXP               int16                Number of exposures included in the coadd for this target
-COADD_EXPTIME              float32 s            Sum of input exposure times
-COADD_NUMNIGHT             int16                Number of different nights included in the coadd for this target
-COADD_NUMTILE              int16                Number of different tiles included in the coadd for this target
-MEAN_DELTA_X               float32              Mean of fiber X offsets from requested location on focal plane
-RMS_DELTA_X                float32              RMS of fiber X offsets from requested location on focal plane
-MEAN_DELTA_Y               float32              Mean of fiber Y offsets from requested location on focal plane
-RMS_DELTA_Y                float32              RMS of fiber Y offsets from requested location on focal plane
-MEAN_FIBER_RA              float64 deg          Mean of fiber RA locations on sky
-STD_FIBER_RA               float32 deg          Standard deviation of fiber RA locations on sky
-MEAN_FIBER_DEC             float64 deg          Mean of fiber Declination locations on sky
-STD_FIBER_DEC              float32 deg          Standard deviation of fiber Declination locations on sky
+SCND_TARGET [1]_           int64                Target selection bitmask for secondary programs
+PLATE_RA                   float64 deg          Right Ascension to be used by PlateMaker
+PLATE_DEC                  float64 deg          Declination to be used by PlateMaker
+TILEID                     int32                Unique DESI tile ID
+COADD_NUMEXP               int16                Number of exposures in coadd
+COADD_EXPTIME              float32 s            Summed exposure time for coadd
+COADD_NUMNIGHT             int16                Number of nights in coadd
+COADD_NUMTILE              int16                Number of tiles in coadd
+MEAN_DELTA_X               float32 mm           Mean (over exposures) fiber difference requested - actual CS5 X location on focal plane
+RMS_DELTA_X                float32 mm           RMS (over exposures) of the fiber difference between measured and requested CS5 X location on focal plane
+MEAN_DELTA_Y               float32 mm           Mean (over exposures) fiber difference requested - actual CS5 Y location on focal plane
+RMS_DELTA_Y                float32 mm           RMS (over exposures) of the fiber difference between measured and requested CS5 Y location on focal plane
+MEAN_FIBER_RA              float64 deg          Mean (over exposures) RA of actual fiber position
+STD_FIBER_RA               float32 arcsec       Standard deviation (over exposures) of RA of actual fiber position
+MEAN_FIBER_DEC             float64 deg          Mean (over exposures) DEC of actual fiber position
+STD_FIBER_DEC              float32 arcsec       Standard deviation (over exposures) of DEC of actual fiber position
 MEAN_PSF_TO_FIBER_SPECFLUX float32              Mean of input exposures fraction of light from point-like source captured by 1.5 arcsec diameter fiber given atmospheric seeing
 MEAN_FIBER_X               float32              Mean of fiber X locations on focal plane for this target
 MEAN_FIBER_Y               float32              Mean of fiber Y locations on focal plane for this target
@@ -251,36 +251,36 @@ Required Data Table Columns
 
 .. rst-class:: columns
 
-===================== ======= ===== =============================================================================================================================
-Name                  Type    Units Description
-===================== ======= ===== =============================================================================================================================
-TARGETID              int64         Unique target ID
-PRIORITY              int32         Assignment priority; larger=higher priority
-SUBPRIORITY           float64       Assignment subpriority [0-1)
-NIGHT                 int32         YEARMMDD date of sunset for the night of this observation
-EXPID                 int32         DESI exposure ID
-MJD                   float64       Modified Julien Date
-TILEID                int32         DESI tile ID
-EXPTIME               float64 s     Exposure time
-PETAL_LOC             int16         Petal location [0-9]
-DEVICE_LOC            int32         Device location on focal plane [0-523]
-LOCATION              int64         FP location PETAL_LOC*1000 + DEVICE_LOC
-FIBER                 int32         Fiber ID on the CCDs [0-4999]
-FIBERSTATUS           int32         Fiber status; 0=good
-FIBERASSIGN_X         float32       Expected CS5 X on focal plane
-FIBERASSIGN_Y         float32       Expected CS5 Y on focal plane
-LAMBDA_REF            float32       Wavelength at which fiber was centered
-PLATE_RA              float64 deg   Right Ascension for Platemaker to use [degrees]
-PLATE_DEC             float64 deg   declination for Platemaker to use [degrees]
-NUM_ITER              int64         Number of positioner iterations
-FIBER_X               float64       CS5 X location requested by PlateMaker
-FIBER_Y               float64       CS5 Y location requested by PlateMaker
-DELTA_X               float64       CS5 X diff requested and actual position
-DELTA_Y               float64       CS5 Y diff requested and actual position
-FIBER_RA              float64 deg   RA of actual fiber position
-FIBER_DEC             float64 deg   DEC of actual fiber position
-PSF_TO_FIBER_SPECFLUX float64       Fraction of light from a point-source captured by a 1.5 arcsec diameter fiber given the astmospheric seeing for this exposure
-===================== ======= ===== =============================================================================================================================
+===================== ======= ======== =======================================================================================================
+Name                  Type    Units    Description
+===================== ======= ======== =======================================================================================================
+TARGETID              int64            Unique DESI target ID
+PRIORITY              int32            Target current priority
+SUBPRIORITY           float64          Random subpriority [0-1) to break assignment ties
+NIGHT                 int32
+EXPID                 int32            DESI Exposure ID number
+MJD                   float64          Modified Julian Date when shutter was opened for this exposure
+TILEID                int32            Unique DESI tile ID
+EXPTIME               float64 s        Length of time shutter was open
+PETAL_LOC             int16            Petal location [0-9]
+DEVICE_LOC            int32            Device location on focal plane [0-523]
+LOCATION              int64            Location on the focal plane PETAL_LOC*1000 + DEVICE_LOC
+FIBER                 int32            Fiber ID on the CCDs [0-4999]
+FIBERSTATUS           int32            Fiber status mask. 0=good
+FIBERASSIGN_X         float32 mm       Fiberassign expected CS5 X location on focal plane
+FIBERASSIGN_Y         float32 mm       Fiberassign expected CS5 Y location on focal plane
+LAMBDA_REF            float32 Angstrom Requested wavelength at which targets should be centered on fibers
+PLATE_RA              float64 deg      Right Ascension to be used by PlateMaker
+PLATE_DEC             float64 deg      Declination to be used by PlateMaker
+NUM_ITER              int64            Number of positioner iterations
+FIBER_X               float64 mm       CS5 X location requested by PlateMaker
+FIBER_Y               float64 mm       CS5 Y location requested by PlateMaker
+DELTA_X               float64 mm       CS5 X requested minus actual position
+DELTA_Y               float64 mm       CS5 Y requested minus actual position
+FIBER_RA              float64 deg      RA of actual fiber position
+FIBER_DEC             float64 deg      DEC of actual fiber position
+PSF_TO_FIBER_SPECFLUX float64          fraction of light from point-like source captured by 1.5 arcsec diameter fiber given atmospheric seeing
+===================== ======= ======== =======================================================================================================
 
 HDU03
 -----
@@ -719,7 +719,7 @@ Required Data Table Columns
 =================== ======= ===== ============================================
 Name                Type    Units Description
 =================== ======= ===== ============================================
-TARGETID            int64         DESI Unique Target ID
+TARGETID            int64         Unique DESI target ID
 INTEG_COADD_FLUX_B  float32       integ. flux in wave. range 4000,5800A
 MEDIAN_COADD_FLUX_B float32       median flux in wave. range 4000,5800A
 MEDIAN_COADD_SNR_B  float32       median SNR/sqrt(A) in wave. range 4000,5800A

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/tiles/GROUPTYPE/TILEID/GROUPID/emline-SPECTROGRAPH-TILEID-GROUPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/tiles/GROUPTYPE/TILEID/GROUPID/emline-SPECTROGRAPH-TILEID-GROUPID.rst
@@ -67,90 +67,90 @@ Required Data Table Columns
 
 .. rst-class:: columns
 
-================= ======= ================================= ===================
+================= ======= ================================= ====================================================================================================================
 Name              Type    Units                             Description
-================= ======= ================================= ===================
-TARGETID          int64                                     Unique targeting ID
-Z                 float64                                   Redshift used for fitting (from the redrock file)
-ZWARN             int64                                     Redshift warning flag (from the redrock file)
-SPECTYPE          char[6]                                   Spectroscopic type (from the redrock file)
-DELTACHI2         float64                                   Chi2 difference between the first- and second best redshifts (from the redrock file)
-TARGET_RA         float64 deg                               Right ascension (from the redrock file)
-TARGET_DEC        float64 deg                               Declination (from the redrock file)
-OBJTYPE           char[3]                                   TGT, SKY, BAD, empty (from the redrock file)
+================= ======= ================================= ====================================================================================================================
+TARGETID          int64                                     Unique DESI target ID
+Z                 float64                                   Redshift measured by Redrock
+ZWARN             int64                                     Redshift warning bitmask from Redrock
+SPECTYPE          char[6]                                   Spectral type of Redrock best fit template (e.g. GALAXY, QSO, STAR)
+DELTACHI2         float64                                   chi2 difference between first- and second-best redrock template fits
+TARGET_RA         float64 deg                               Target right ascension
+TARGET_DEC        float64 deg                               Target declination
+OBJTYPE           char[3]                                   Object type: TGT, SKY, NON, BAD
 OII_FLUX          float32 10**-17 erg/(s cm2)               Fitted flux for the [OII] doublet
 OII_FLUX_IVAR     float32 10**+34 (s2 cm4) / erg2           Inverse variance of the fitted flux for the [OII] doublet
 OII_SIGMA         float32 Angstrom                          Fitted line width (in the observed frame) for the [OII] doublet
 OII_SIGMA_IVAR    float32 Angstrom^-2                       Inverse variance of the fitted line width (in the observed frame) for the [OII] doublet
 OII_CONT          float32 10**-17 erg/(s cm2 Angstrom)      Continuum used for the fitting (fixed value) for the [OII] doublet
-OII_CONT_IVAR     float32 10**+34 (s2 cm4 Angstrom2) / erg2 Inverse variance of the continuum
+OII_CONT_IVAR     float32 10**+34 (s2 cm4 Angstrom2) / erg2 Inverse variance of the continuum for the [OII] doublet
 OII_SHARE         float32                                   Fitted F1/(F0+F1) for the [OII] doublet, where F0 and F1 are the individual line fluxes
 OII_SHARE_IVAR    float32                                   Inverse variance of the fitted F1/(F0+F1) for the [OII] doublet
 OII_EW            float32 Angstrom                          Fitted rest-frame equivalent width for the [OII] doublet
 OII_EW_IVAR       float32 Angstrom^-2                       Inverse variance of the fitted rest-frame equivalent width for the [OII] doublet
 OII_CHI2          float32                                   Reduced chi2 of the fit for the [OII] doublet
 OII_NDOF          int32                                     Number of degrees of freedom of the fit for the [OII] doublet
-HDELTA_FLUX       float32 10**-17 erg/(s cm2)               Same as OII_FLUX but for the HDELTA line
-HDELTA_FLUX_IVAR  float32 10**+34 (s2 cm4) / erg2           Same as OII_FLUX_IVAR but for the HDELTA line
-HDELTA_SIGMA      float32 Angstrom                          Same as OII_SIGMA but for the HDELTA line
-HDELTA_SIGMA_IVAR float32 Angstrom^-2                       Same as OII_SIGMA_IVAR but for the HDELTA line
-HDELTA_CONT       float32 10**-17 erg/(s cm2 Angstrom)      Same as OII_CONT but for the HDELTA line
-HDELTA_CONT_IVAR  float32 10**+34 (s2 cm4 Angstrom2) / erg2 Same as OII_CONT_IVAR but for the HDELTA line
+HDELTA_FLUX       float32 10**-17 erg/(s cm2)               Fitted flux for the HDELTA line
+HDELTA_FLUX_IVAR  float32 10**+34 (s2 cm4) / erg2           Inverse variance of the fitted flux for the HDELTA line
+HDELTA_SIGMA      float32 Angstrom                          Fitted line width (in the observed frame) for the HDELTA line
+HDELTA_SIGMA_IVAR float32 Angstrom^-2                       Inverse variance of the fitted line width (in the observed frame) for the HDELTA line
+HDELTA_CONT       float32 10**-17 erg/(s cm2 Angstrom)      Continuum used for the fitting (fixed value) for the HDELTA line
+HDELTA_CONT_IVAR  float32 10**+34 (s2 cm4 Angstrom2) / erg2 Inverse variance of the continuum for the HDELTA line
 HDELTA_SHARE      float32                                   NaN (SHARE not relevant for HDELTA line)
 HDELTA_SHARE_IVAR float32                                   NaN (SHARE not relevant for HDELTA line)
-HDELTA_EW         float32 Angstrom                          Same as OII_EW but for the HDELTA line
-HDELTA_EW_IVAR    float32 Angstrom^-2                       Same as OII_EW_IVAR but for the HDELTA line
-HDELTA_CHI2       float32                                   Same as OII_CHI2 but for the HDELTA line
-HDELTA_NDOF       int32                                     Same as OII_NDOF but for the HDELTA line
-HGAMMA_FLUX       float32 10**-17 erg/(s cm2)               Same as OII_FLUX but for the HGAMMA line
-HGAMMA_FLUX_IVAR  float32 10**+34 (s2 cm4) / erg2           Same as OII_FLUX_IVAR but for the HGAMMA line
-HGAMMA_SIGMA      float32 Angstrom                          Same as OII_SIGMA but for the HGAMMA line
-HGAMMA_SIGMA_IVAR float32 Angstrom^-2                       Same as OII_SIGMA_IVAR but for the HGAMMA line
-HGAMMA_CONT       float32 10**-17 erg/(s cm2 Angstrom)      Same as OII_CONT but for the HGAMMA line
-HGAMMA_CONT_IVAR  float32 10**+34 (s2 cm4 Angstrom2) / erg2 Same as OII_CONT_IVAR but for the HGAMMA line
+HDELTA_EW         float32 Angstrom                          Fitted rest-frame equivalent width for the HDELTA line
+HDELTA_EW_IVAR    float32 Angstrom^-2                       Inverse variance of the fitted rest-frame equivalent width for the HDELTA line
+HDELTA_CHI2       float32                                   Reduced chi2 of the fit for the HDELTA line
+HDELTA_NDOF       int32                                     Number of degrees of freedom of the fit for the HDELTA line
+HGAMMA_FLUX       float32 10**-17 erg/(s cm2)               Fitted flux for the HGAMMA line
+HGAMMA_FLUX_IVAR  float32 10**+34 (s2 cm4) / erg2           Inverse variance of the fitted flux for the HGAMMA line
+HGAMMA_SIGMA      float32 Angstrom                          Fitted line width (in the observed frame) for the HGAMMA line
+HGAMMA_SIGMA_IVAR float32 Angstrom^-2                       Inverse variance of the fitted line width (in the observed frame) for the HGAMMA line
+HGAMMA_CONT       float32 10**-17 erg/(s cm2 Angstrom)      Continuum used for the fitting (fixed value) for the HGAMMA line
+HGAMMA_CONT_IVAR  float32 10**+34 (s2 cm4 Angstrom2) / erg2 Inverse variance of the continuum for the HGAMMA line
 HGAMMA_SHARE      float32                                   NaN (SHARE not relevant for HGAMMA line)
 HGAMMA_SHARE_IVAR float32                                   NaN (SHARE not relevant for HGAMMA line)
-HGAMMA_EW         float32 Angstrom                          Same as OII_EW but for the HGAMMA line
-HGAMMA_EW_IVAR    float32 Angstrom^-2                       Same as OII_EW_IVAR but for the HGAMMA line
-HGAMMA_CHI2       float32                                   Same as OII_CHI2 but for the HGAMMA line
-HGAMMA_NDOF       int32                                     Same as OII_NDOF but for the HGAMMA line
-HBETA_FLUX        float32 10**-17 erg/(s cm2)               Same as OII_FLUX but for the HBETA line
-HBETA_FLUX_IVAR   float32 10**+34 (s2 cm4) / erg2           Same as OII_FLUX_IVAR but for the HBETA line
-HBETA_SIGMA       float32 Angstrom                          Same as OII_SIGMA but for the HBETA line
-HBETA_SIGMA_IVAR  float32 Angstrom^-2                       Same as OII_SIGMA_IVAR but for the HBETA line
-HBETA_CONT        float32 10**-17 erg/(s cm2 Angstrom)      Same as OII_CONT but for the HBETA line
-HBETA_CONT_IVAR   float32 10**+34 (s2 cm4 Angstrom2) / erg2 Same as OII_CONT_IVAR but for the HBETA line
+HGAMMA_EW         float32 Angstrom                          Fitted rest-frame equivalent width for the HGAMMA line
+HGAMMA_EW_IVAR    float32 Angstrom^-2                       Inverse variance of the fitted rest-frame equivalent width for the HGAMMA line
+HGAMMA_CHI2       float32                                   Reduced chi2 of the fit for the HGAMMA line
+HGAMMA_NDOF       int32                                     Number of degrees of freedom of the fit for the HGAMMA line
+HBETA_FLUX        float32 10**-17 erg/(s cm2)               Fitted flux for the HBETA line
+HBETA_FLUX_IVAR   float32 10**+34 (s2 cm4) / erg2           Inverse variance of the fitted flux for the HBETA line
+HBETA_SIGMA       float32 Angstrom                          Fitted line width (in the observed frame) for the HBETA line
+HBETA_SIGMA_IVAR  float32 Angstrom^-2                       Inverse variance of the fitted line width (in the observed frame) for the HBETA line
+HBETA_CONT        float32 10**-17 erg/(s cm2 Angstrom)      Continuum used for the fitting (fixed value) for the HBETA line
+HBETA_CONT_IVAR   float32 10**+34 (s2 cm4 Angstrom2) / erg2 Inverse variance of the continuum for the HBETA line
 HBETA_SHARE       float32                                   NaN (SHARE not relevant for HBETA line)
 HBETA_SHARE_IVAR  float32                                   NaN (SHARE not relevant for HBETA line)
-HBETA_EW          float32 Angstrom                          Same as OII_EW but for the HBETA line
-HBETA_EW_IVAR     float32 Angstrom^-2                       Same as OII_EW_IVAR but for the HBETA line
-HBETA_CHI2        float32                                   Same as OII_CHI2 but for the HBETA line
-HBETA_NDOF        int32                                     Same as OII_NDOF but for the HBETA line
-OIII_FLUX         float32 10**-17 erg/(s cm2)               Same as OII_FLUX but for the [OIII] doublet
-OIII_FLUX_IVAR    float32 10**+34 (s2 cm4) / erg2           Same as OII_FLUX_IVAR but for the [OIII] doublet
-OIII_SIGMA        float32 Angstrom                          Same as OII_SIGMA but for the [OIII] doublet
-OIII_SIGMA_IVAR   float32 Angstrom^-2                       Same as OII_SIGMA_IVAR but for the [OIII] doublet
-OIII_CONT         float32 10**-17 erg/(s cm2 Angstrom)      Same as OII_CONT but for the [OIII] doublet
-OIII_CONT_IVAR    float32 10**+34 (s2 cm4 Angstrom2) / erg2 Same as OII_CONT_IVAR but for the [OIII] doublet
+HBETA_EW          float32 Angstrom                          Fitted rest-frame equivalent width for the HBETA line
+HBETA_EW_IVAR     float32 Angstrom^-2                       Inverse variance of the fitted rest-frame equivalent width for the HBETA line
+HBETA_CHI2        float32                                   Reduced chi2 of the fit for the HBETA line
+HBETA_NDOF        int32                                     Number of degrees of freedom of the fit for the HBETA line
+OIII_FLUX         float32 10**-17 erg/(s cm2)               Fitted flux for the [OIII] doublet
+OIII_FLUX_IVAR    float32 10**+34 (s2 cm4) / erg2           Inverse variance of the fitted flux for the [OIII] doublet
+OIII_SIGMA        float32 Angstrom                          Fitted line width (in the observed frame) for the [OIII] doublet
+OIII_SIGMA_IVAR   float32 Angstrom^-2                       Inverse variance of the fitted line width (in the observed frame) for the [OIII] doublet
+OIII_CONT         float32 10**-17 erg/(s cm2 Angstrom)      Continuum used for the fitting (fixed value) for the [OIII] doublet
+OIII_CONT_IVAR    float32 10**+34 (s2 cm4 Angstrom2) / erg2 Inverse variance of the continuum for the [OIII] doublet
 OIII_SHARE        float32                                   F1/(F0+F1) for the [OIII] doublet, where F0 and F1 are the individual line fluxes (SHARE value fixed during the fit)
-OIII_SHARE_IVAR   float32                                   Infinite value, as SHARE is fixed during the fit)
-OIII_EW           float32 Angstrom                          Same as OII_EW but for the [OIII] doublet
-OIII_EW_IVAR      float32 Angstrom^-2                       Same as OII_EW_IVAR but for the [OIII] doublet
-OIII_CHI2         float32                                   Same as OII_CHI2 but for the [OIII] doublet
-OIII_NDOF         int32                                     Same as OII_NDOF but for the [OIII] doublet
-HALPHA_FLUX       float32 10**-17 erg/(s cm2)               Same as OII_FLUX but for the HALPHA line
-HALPHA_FLUX_IVAR  float32 10**+34 (s2 cm4) / erg2           Same as OII_FLUX_IVAR but for the HALPHA line
-HALPHA_SIGMA      float32 Angstrom                          Same as OII_SIGMA but for the HALPHA line
-HALPHA_SIGMA_IVAR float32 Angstrom^-2                       Same as OII_SIGMA_IVAR but for the HALPHA line
-HALPHA_CONT       float32 10**-17 erg/(s cm2 Angstrom)      Same as OII_CONT but for the HALPHA line
-HALPHA_CONT_IVAR  float32 10**+34 (s2 cm4 Angstrom2) / erg2 Same as OII_CONT_IVAR but for the HALPHA line
+OIII_SHARE_IVAR   float32                                   Infinite value, as SHARE is fixed during the fit
+OIII_EW           float32 Angstrom                          Fitted rest-frame equivalent width for the [OIII] doublet
+OIII_EW_IVAR      float32 Angstrom^-2                       Inverse variance of the fitted rest-frame equivalent width for the [OIII] doublet
+OIII_CHI2         float32                                   Reduced chi2 of the fit for the [OIII] doublet
+OIII_NDOF         int32                                     Number of degrees of freedom of the fit for the [OIII] doublet
+HALPHA_FLUX       float32 10**-17 erg/(s cm2)               Fitted flux for the HALPHA line
+HALPHA_FLUX_IVAR  float32 10**+34 (s2 cm4) / erg2           Inverse variance of the fitted flux for the HALPHA line
+HALPHA_SIGMA      float32 Angstrom                          Fitted line width (in the observed frame) for the HALPHA line
+HALPHA_SIGMA_IVAR float32 Angstrom^-2                       Inverse variance of the fitted line width (in the observed frame) for the HALPHA line
+HALPHA_CONT       float32 10**-17 erg/(s cm2 Angstrom)      Continuum used for the fitting (fixed value) for the HALPHA line
+HALPHA_CONT_IVAR  float32 10**+34 (s2 cm4 Angstrom2) / erg2 Inverse variance of the continuum for the HALPHA line
 HALPHA_SHARE      float32                                   NaN (SHARE not relevant for HALPHA line)
 HALPHA_SHARE_IVAR float32                                   NaN (SHARE not relevant for HALPHA line)
-HALPHA_EW         float32 Angstrom                          Same as OII_EW but for the HALPHA line
-HALPHA_EW_IVAR    float32 Angstrom^-2                       Same as OII_EW_IVAR but for the HALPHA line
-HALPHA_CHI2       float32                                   Same as OII_CHI2 but for the HALPHA line
-HALPHA_NDOF       int32                                     Same as OII_NDOF but for the HALPHA line
-================= ======= ================================= ===================
+HALPHA_EW         float32 Angstrom                          Fitted rest-frame equivalent width for the HALPHA line
+HALPHA_EW_IVAR    float32 Angstrom^-2                       Inverse variance of the fitted rest-frame equivalent width for the HALPHA line
+HALPHA_CHI2       float32                                   Reduced chi2 of the fit for the HALPHA line
+HALPHA_NDOF       int32                                     Number of degrees of freedom of the fit for the HALPHA line
+================= ======= ================================= ====================================================================================================================
 
 
 Notes and Examples

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/tiles/GROUPTYPE/TILEID/GROUPID/qso_mgii-SPECTROGRAPH-TILEID-GROUPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/tiles/GROUPTYPE/TILEID/GROUPID/qso_mgii-SPECTROGRAPH-TILEID-GROUPID.rst
@@ -57,18 +57,18 @@ Required Data Table Columns
 
 .. rst-class:: columns
 
-==================== ======== ===== ===================
+==================== ======== ===== ==============================================================================================================
 Name                 Type     Units Description
-==================== ======== ===== ===================
-TARGETID             int64          Unique target ID
-RA                   float64        Target Right Ascension [degrees]
-DEC                  float64        Target declination [degrees]
+==================== ======== ===== ==============================================================================================================
+TARGETID             int64          Unique DESI target ID
+RA                   float64  deg   Target Right Ascension
+DEC                  float64  deg   Target declination
 Z_RR                 float64        Redshift collected from redrock file
-ZERR                 float32        Redshift error from redrock file
-IS_QSO_MGII          logical        Is the object pass the MgII selection?
-SV1_DESI_TARGET [1]_ int64          Dark survey + calibration targeting bits for SV1
-DESI_TARGET [1]_     int64          Dark survey + calibration targeting bits
-SPECTYPE             char[10]       Spectype from redrock file
+ZERR                 float32        Redshift error from redrock
+IS_QSO_MGII          logical        Boolean: True if the object passes the MgII selection
+SV1_DESI_TARGET [1]_ int64          DESI (dark time program) target selection bitmask for SV1
+DESI_TARGET [1]_     int64          DESI (dark time program) target selection bitmask
+SPECTYPE             char[10]       Spectral type of Redrock best fit template (e.g. GALAXY, QSO, STAR)
 DELTA_CHI2           float32        Difference of chi2 between redrock fit and MgII fitter over the lambda interval considered during the fit [2]_
 A                    float32        fitted parameter by MgII fitter [2]_ [3]_
 SIGMA                float32        fitted parameter by MgII fitter [2]_ [3]_
@@ -76,7 +76,7 @@ B                    float32        fitted parameter by MgII fitter [3]_
 VAR_A                float32        error on A [2]_
 VAR_SIGMA            float32        error on SIGMA
 VAR_B                float32        error on B
-==================== ======== ===== ===================
+==================== ======== ===== ==============================================================================================================
 
 .. [1] Optional
 

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/tiles/GROUPTYPE/TILEID/GROUPID/qso_qn-SPECTROGRAPH-TILEID-GROUPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/tiles/GROUPTYPE/TILEID/GROUPID/qso_qn-SPECTROGRAPH-TILEID-GROUPID.rst
@@ -71,15 +71,15 @@ DESI_TARGET [1]_     int64             DESI (dark time program) target selection
 COEFFS               float32[10]       Coefficient of the fit for the new run of redrock
 SPECTYPE             char[10]          Spectral type of Redrock best fit template (e.g. GALAXY, QSO, STAR)
 Z_RR                 float32           Redshift collected from redrock file
-Z_QN                 float32           Redshift measured by QuasarNET
-IS_QSO_QN_NEW_RR     logical           Is the object detected QSO with quasarnp and a new redshift fit with prior is performed?
-C_LYA                float32           Confidence line for LYA, i.e. ~probability to be a QSO
-C_CIV                float32           Confidence line for CIV
-C_CIII               float32           Confidence line for CIII
-C_MgII               float32           Confidence line for MgII
-C_Hbeta              float32           Confidence line for Hbeta
-C_Halpha             float32           Confidence line for Halpha
-Z_LYA                float32           Redshift estimated by QuasarNET with LYA line
+Z_QN                 float32           Redshift measured by QuasarNET using line with highest confidence
+IS_QSO_QN_NEW_RR     bool              QN identified as QSO at different redshift or classification than Redrock
+C_LYA                float32           Confidence for LyA line, i.e. ~probability to be a QSO
+C_CIV                float32           Confidence for CIV line
+C_CIII               float32           Confidence for CIII line
+C_MgII               float32           Confidence for MgII line
+C_Hbeta              float32           Confidence for Hbeta line
+C_Halpha             float32           Confidence for Halpha line
+Z_LYA                float32           Redshift estimated by QuasarNET with LyA line
 Z_CIV                float32           Redshift estimated by QuasarNET with CIV line
 Z_CIII               float32           Redshift estimated by QuasarNET with CIII line
 Z_MgII               float32           Redshift estimated by QuasarNET with MgII line
@@ -91,11 +91,18 @@ Z_Halpha             float32           Redshift estimated by QuasarNET with Halp
 
 Notes:
 
- * Z_QN is the redshift estimated on the line of the highest confidence
- * The QN selection is performed with the C_XXX parameters. As it stands, in QN afterburner everything with np.max(confidence) > 0.5 is considered as a quasar. However, specific cut will be used depending on each target class; QSO_target will use np.max(confidence) > 0.95.
-       See: https://github.com/echaussidon/desispec/blob/720153babcf85dd93530252b0c1f631d48edfc0d/bin/desi_qso_qn_afterburner#L236
+``IS_QSO_QN_NEW_RR`` is set if QuasarNET selects this as a QSO *and* the answer
+is different from Redrock, either because Redrock didn't identify it as a QSO
+or because the Redrock redshift differed by more than 0.05.  If both
+QuasarNET and Redrock agree that it is a QSO and agree on the redshift, then
+``IS_QSO_QN_NEW_RR=False``.
+
+The QuasarNET QSO selection is performed with the C_XXX confidence parameters.
+``IS_QSO_QN_NEW_RR`` uses a relatively loose cut of ``max(C_XXX) >= 0.5``;
+downstream code may choose to use a tighter cut.
+
 
 Notes and Examples
 ==================
 
-These files are generated with https://github.com/desihub/desispec/blob/master/bin/desi_qso_qn_afterburner
+These files are generated with https://github.com/desihub/desispec/blob/main/bin/desi_qso_qn_afterburner

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/tiles/GROUPTYPE/TILEID/GROUPID/qso_qn-SPECTROGRAPH-TILEID-GROUPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/tiles/GROUPTYPE/TILEID/GROUPID/qso_qn-SPECTROGRAPH-TILEID-GROUPID.rst
@@ -58,40 +58,41 @@ Required Data Table Columns
 
 .. rst-class:: columns
 
-==================== =========== ===== ===================
+==================== =========== ===== ========================================================================================
 Name                 Type        Units Description
-==================== =========== ===== ===================
-TARGETID             int64             Unique target ID
-RA                   float64           Target Right Ascension [degrees]
-DEC                  float64           Target declination [degrees]
+==================== =========== ===== ========================================================================================
+TARGETID             int64             Unique DESI target ID
+RA                   float64     deg   Target Right Ascension
+DEC                  float64     deg   Target declination
 Z_NEW                float64           New redshift computed with redrock with QN prior and only qso templates
 ZERR_NEW             float32           Redshift error from the new run of redrock
-SV1_DESI_TARGET [1]_ int64             Dark survey + calibration targeting bits for SV1
-DESI_TARGET [1]_     int64             Dark survey + calibration targeting bits
+SV1_DESI_TARGET [1]_ int64             DESI (dark time program) target selection bitmask for SV1
+DESI_TARGET [1]_     int64             DESI (dark time program) target selection bitmask
 COEFFS               float32[10]       Coefficient of the fit for the new run of redrock
-SPECTYPE             char[10]          Spectype from the redrock file
+SPECTYPE             char[10]          Spectral type of Redrock best fit template (e.g. GALAXY, QSO, STAR)
 Z_RR                 float32           Redshift collected from redrock file
-Z_QN                 float32           Redshift computed with quasarnp [2]_
+Z_QN                 float32           Redshift measured by QuasarNET
 IS_QSO_QN_NEW_RR     logical           Is the object detected QSO with quasarnp and a new redshift fit with prior is performed?
-C_LYA                float32           Confidence line for LYA (*i.e.*) ~ probability to be a QSO [3]_
-C_CIV                float32           Confidence line for CIV [3]_
-C_CIII               float32           Confidence line for CIII [3]_
-C_MgII               float32           Confidence line for MgII [3]_
-C_Hbeta              float32           Confidence line for Hbeta [3]_
-C_Halpha             float32           Confidence line for Halpha [3]_
-Z_LYA                float32           Redshift estimated by quasarnp with LYA line [2]_
-Z_CIV                float32           Redshift estimated by quasarnp with CIV line [2]_
-Z_CIII               float32           Redshift estimated by quasarnp with CIII line [2]_
-Z_MgII               float32           Redshift estimated by quasarnp with MgII line [2]_
-Z_Hbeta              float32           Redshift estimated by quasarnp with Hbeta line [2]_
-Z_Halpha             float32           Redshift estimated by quasarnp with Halpha line [2]_
-==================== =========== ===== ===================
+C_LYA                float32           Confidence line for LYA, i.e. ~probability to be a QSO
+C_CIV                float32           Confidence line for CIV
+C_CIII               float32           Confidence line for CIII
+C_MgII               float32           Confidence line for MgII
+C_Hbeta              float32           Confidence line for Hbeta
+C_Halpha             float32           Confidence line for Halpha
+Z_LYA                float32           Redshift estimated by QuasarNET with LYA line
+Z_CIV                float32           Redshift estimated by QuasarNET with CIV line
+Z_CIII               float32           Redshift estimated by QuasarNET with CIII line
+Z_MgII               float32           Redshift estimated by QuasarNET with MgII line
+Z_Hbeta              float32           Redshift estimated by QuasarNET with Hbeta line
+Z_Halpha             float32           Redshift estimated by QuasarNET with Halpha line
+==================== =========== ===== ========================================================================================
 
 .. [1] Optional
 
-.. [2] Z_QN is the redshift estimated on the line of the highest confidence
+Notes:
 
-.. [3] The QN selection is performed with these parameters. As it stands, in QN afterburner everything with np.max(confindence) > 0.5 is considered as a quasar. However, specific cut will be used depends on each target class; QSO_target will use np.max(confidence) > 0.95.
+ * Z_QN is the redshift estimated on the line of the highest confidence
+ * The QN selection is performed with the C_XXX parameters. As it stands, in QN afterburner everything with np.max(confidence) > 0.5 is considered as a quasar. However, specific cut will be used depending on each target class; QSO_target will use np.max(confidence) > 0.95.
        See: https://github.com/echaussidon/desispec/blob/720153babcf85dd93530252b0c1f631d48edfc0d/bin/desi_qso_qn_afterburner#L236
 
 Notes and Examples

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/tiles/GROUPTYPE/TILEID/GROUPID/redrock-SPECTROGRAPH-TILEID-GROUPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/tiles/GROUPTYPE/TILEID/GROUPID/redrock-SPECTROGRAPH-TILEID-GROUPID.rst
@@ -101,21 +101,21 @@ Required Data Table Columns
 
 .. rst-class:: columns
 
-========= =========== ===== ===========
+========= =========== ===== ====================================================================
 Name      Type        Units Description
-========= =========== ===== ===========
-TARGETID  int64
-CHI2      float64
-COEFF     float64[10]
-Z         float64
-ZERR      float64
-ZWARN     int64
+========= =========== ===== ====================================================================
+TARGETID  int64             Unique DESI target ID
+CHI2      float64           Best fit chi squared
+COEFF     float64[10]       Redrock template coefficients
+Z         float64           Redshift measured by Redrock
+ZERR      float64           Redshift error from redrock
+ZWARN     int64             Redshift warning bitmask from Redrock
 NPIXELS   int64
-SPECTYPE  char[6]
-SUBTYPE   char[20]
-NCOEFF    int64
-DELTACHI2 float64
-========= =========== ===== ===========
+SPECTYPE  char[6]           Spectral type of Redrock best fit template (e.g. GALAXY, QSO, STAR)
+SUBTYPE   char[20]          Spectral subtype
+NCOEFF    int64             Number of Redrock template coefficients
+DELTACHI2 float64           chi2 difference between first- and second-best redrock template fits
+========= =========== ===== ====================================================================
 
 HDU2
 ----
@@ -143,92 +143,92 @@ Required Data Table Columns
 
 .. rst-class:: columns
 
-========================== ======= ===== ===========
-Name                       Type    Units Description
-========================== ======= ===== ===========
-TARGETID                   int64
-PETAL_LOC                  int16
-DEVICE_LOC                 int32
-LOCATION                   int64
+========================== ======= ============ ===============================================================================================================================
+Name                       Type    Units        Description
+========================== ======= ============ ===============================================================================================================================
+TARGETID                   int64                Unique DESI target ID
+PETAL_LOC                  int16                Petal location [0-9]
+DEVICE_LOC                 int32                Device location on focal plane [0-523]
+LOCATION                   int64                Location on the focal plane PETAL_LOC*1000 + DEVICE_LOC
 FIBER                      int32
-COADD_FIBERSTATUS          int32
-TARGET_RA                  float64
-TARGET_DEC                 float64
-PMRA                       float32
-PMDEC                      float32
-REF_EPOCH                  float32
-LAMBDA_REF                 float32
-FA_TARGET                  int64
-FA_TYPE                    binary
-OBJTYPE                    char[3]
-FIBERASSIGN_X              float32
-FIBERASSIGN_Y              float32
-PRIORITY                   int32
-SUBPRIORITY                float64
-OBSCONDITIONS              int32
-RELEASE                    int16
-BRICKNAME                  char[8]
-BRICKID                    int32
-BRICK_OBJID                int32
-MORPHTYPE                  char[4]
-EBV                        float32
-FLUX_G                     float32
-FLUX_R                     float32
-FLUX_Z                     float32
-FLUX_W1                    float32
-FLUX_W2                    float32
-FLUX_IVAR_G                float32
-FLUX_IVAR_R                float32
-FLUX_IVAR_Z                float32
-FLUX_IVAR_W1               float32
-FLUX_IVAR_W2               float32
-FIBERFLUX_G                float32
-FIBERFLUX_R                float32
-FIBERFLUX_Z                float32
-FIBERTOTFLUX_G             float32
-FIBERTOTFLUX_R             float32
-FIBERTOTFLUX_Z             float32
-MASKBITS                   int16
-SERSIC                     float32
-SHAPE_R                    float32
-SHAPE_E1                   float32
-SHAPE_E2                   float32
-REF_ID                     int64
-REF_CAT                    char[2]
-GAIA_PHOT_G_MEAN_MAG       float32
-GAIA_PHOT_BP_MEAN_MAG      float32
-GAIA_PHOT_RP_MEAN_MAG      float32
-PARALLAX                   float32
-PHOTSYS                    char[1]
-PRIORITY_INIT              int64
-NUMOBS_INIT                int64
-SV1_DESI_TARGET [1]_       int64
-SV1_BGS_TARGET [1]_        int64
-SV1_MWS_TARGET [1]_        int64
-SV1_SCND_TARGET [1]_       int64
-DESI_TARGET                int64
-BGS_TARGET                 int64
-MWS_TARGET                 int64
-SCND_TARGET [1]_           int64
-PLATE_RA                   float64
-PLATE_DEC                  float64
-TILEID                     int32
-COADD_NUMEXP               int16
-COADD_EXPTIME              float32
-COADD_NUMNIGHT             int16
-COADD_NUMTILE              int16
-MEAN_DELTA_X               float32
-RMS_DELTA_X                float32
-MEAN_DELTA_Y               float32
-RMS_DELTA_Y                float32
-MEAN_FIBER_RA              float64
-STD_FIBER_RA               float32
-MEAN_FIBER_DEC             float64
-STD_FIBER_DEC              float32
-MEAN_PSF_TO_FIBER_SPECFLUX float32
+COADD_FIBERSTATUS          int32                bitwise-AND of input FIBERSTATUS
+TARGET_RA                  float64 deg          Target right ascension
+TARGET_DEC                 float64 deg          Target declination
+PMRA                       float32 mas yr^-1    proper motion in the +RA direction (already including cos(dec))
+PMDEC                      float32 mas yr^-1    Proper motion in the +Dec direction
+REF_EPOCH                  float32 yr           Reference epoch for Gaia/Tycho astrometry. Typically 2015.5 for Gaia
+LAMBDA_REF                 float32 Angstrom     Requested wavelength at which targets should be centered on fibers
+FA_TARGET                  int64                Targeting bit internally used by fiberassign (linked with FA_TYPE)
+FA_TYPE                    binary               Fiberassign internal target type (science, standard, sky, safe, suppsky)
+OBJTYPE                    char[3]              Object type: TGT, SKY, NON, BAD
+FIBERASSIGN_X              float32 mm           Fiberassign expected CS5 X location on focal plane
+FIBERASSIGN_Y              float32 mm           Fiberassign expected CS5 Y location on focal plane
+PRIORITY                   int32                Target current priority
+SUBPRIORITY                float64              Random subpriority [0-1) to break assignment ties
+OBSCONDITIONS              int32                Bitmask of allowed observing conditions
+RELEASE                    int16                Imaging surveys release ID
+BRICKNAME                  char[8]              Brick name from tractor input
+BRICKID                    int32                Brick ID from tractor input
+BRICK_OBJID                int32                Imaging Surveys OBJID on that brick
+MORPHTYPE                  char[4]              Imaging Surveys morphological type from Tractor
+EBV                        float32 mag          Galactic extinction E(B-V) reddening from SFD98
+FLUX_G                     float32 nanomaggy    Flux in the Legacy Survey g-band (AB)
+FLUX_R                     float32 nanomaggy    Flux in the Legacy Survey r-band (AB)
+FLUX_Z                     float32 nanomaggy    Flux in the Legacy Survey z-band (AB)
+FLUX_W1                    float32 nanomaggy    WISE flux in W1 (AB)
+FLUX_W2                    float32 nanomaggy    WISE flux in W2 (AB)
+FLUX_IVAR_G                float32 nanomaggy^-2 Inverse variance of FLUX_G (AB)
+FLUX_IVAR_R                float32 nanomaggy^-2 Inverse variance of FLUX_R (AB)
+FLUX_IVAR_Z                float32 nanomaggy^-2 Inverse variance of FLUX_Z (AB)
+FLUX_IVAR_W1               float32 nanomaggy^-2 Inverse variance of FLUX_W1 (AB)
+FLUX_IVAR_W2               float32 nanomaggy^-2 Inverse variance of FLUX_W2 (AB)
+FIBERFLUX_G                float32 nanomaggy    Predicted g-band flux within a fiber of diameter 1.5 arcsec from this object in 1 arcsec Gaussian seeing
+FIBERFLUX_R                float32 nanomaggy    Predicted r-band flux within a fiber of diameter 1.5 arcsec from this object in 1 arcsec Gaussian seeing
+FIBERFLUX_Z                float32 nanomaggy    Predicted z-band flux within a fiber of diameter 1.5 arcsec from this object in 1 arcsec Gaussian seeing
+FIBERTOTFLUX_G             float32 nanomaggy    Predicted g-band flux within a fiber of diameter 1.5 arcsec from all sources at this location in 1 arcsec Gaussian seeing
+FIBERTOTFLUX_R             float32 nanomaggy    Predicted r-band flux within a fiber of diameter 1.5 arcsec from all sources at this location in 1 arcsec Gaussian seeing
+FIBERTOTFLUX_Z             float32 nanomaggy    Predicted z-band flux within a fiber of diameter 1.5 arcsec from all sources at this location in 1 arcsec Gaussian seeing
+MASKBITS                   int16                Bitwise mask from the imaging indicating potential issue or blending
+SERSIC                     float32              Power-law index for the Sersic profile model (MORPHTYPE=”SER”)
+SHAPE_R                    float32 arcsec       Half-light radius of galaxy model (&gt;0)
+SHAPE_E1                   float32              Ellipticity component 1 of galaxy model for galaxy type MORPHTYPE
+SHAPE_E2                   float32              Ellipticity component 2 of galaxy model for galaxy type MORPHTYPE
+REF_ID                     int64                Tyc1*1,000,000+Tyc2*10+Tyc3 for Tycho-2; “sourceid” for Gaia DR2
+REF_CAT                    char[2]              Reference catalog source for star: “T2” for Tycho-2, “G2” for Gaia DR2, “L2” for the SGA, empty otherwise
+GAIA_PHOT_G_MEAN_MAG       float32 mag          Gaia G band magnitude
+GAIA_PHOT_BP_MEAN_MAG      float32 mag          Gaia BP band magnitude
+GAIA_PHOT_RP_MEAN_MAG      float32 mag          Gaia RP band magnitude
+PARALLAX                   float32 mas          Reference catalog parallax
+PHOTSYS                    char[1]              &#x27;N&#x27; for the MzLS/BASS photometric system, &#x27;S&#x27; for DECaLS
+PRIORITY_INIT              int64                Target initial priority from target selection bitmasks and OBSCONDITIONS
+NUMOBS_INIT                int64                Initial number of observations for target calculated across target selection bitmasks and OBSCONDITIONS
+SV1_DESI_TARGET [1]_       int64                DESI (dark time program) target selection bitmask for SV1
+SV1_BGS_TARGET [1]_        int64                BGS (bright time program) target selection bitmask for SV1
+SV1_MWS_TARGET [1]_        int64                MWS (bright time program) target selection bitmask for SV1
+SV1_SCND_TARGET [1]_       int64                Secondary target selection bitmask for SV1
+DESI_TARGET                int64                DESI (dark time program) target selection bitmask
+BGS_TARGET                 int64                BGS (Bright Galaxy Survey) target selection bitmask
+MWS_TARGET                 int64                Milky Way Survey targeting bits
+SCND_TARGET [1]_           int64                Target selection bitmask for secondary programs
+PLATE_RA                   float64 deg          Right Ascension to be used by PlateMaker
+PLATE_DEC                  float64 deg          Declination to be used by PlateMaker
+TILEID                     int32                Unique DESI tile ID
+COADD_NUMEXP               int16                Number of exposures in coadd
+COADD_EXPTIME              float32 s            Summed exposure time for coadd
+COADD_NUMNIGHT             int16                Number of nights in coadd
+COADD_NUMTILE              int16                Number of tiles in coadd
+MEAN_DELTA_X               float32 mm           Mean (over exposures) fiber difference requested - actual CS5 X location on focal plane
+RMS_DELTA_X                float32 mm           RMS (over exposures) of the fiber difference between measured and requested CS5 X location on focal plane
+MEAN_DELTA_Y               float32 mm           Mean (over exposures) fiber difference requested - actual CS5 Y location on focal plane
+RMS_DELTA_Y                float32 mm           RMS (over exposures) of the fiber difference between measured and requested CS5 Y location on focal plane
+MEAN_FIBER_RA              float64 deg          Mean (over exposures) RA of actual fiber position
+STD_FIBER_RA               float32 arcsec       Standard deviation (over exposures) of RA of actual fiber position
+MEAN_FIBER_DEC             float64 deg          Mean (over exposures) DEC of actual fiber position
+STD_FIBER_DEC              float32 arcsec       Standard deviation (over exposures) of DEC of actual fiber position
+MEAN_PSF_TO_FIBER_SPECFLUX float32              Mean of input exposures fraction of light from point-like source captured by 1.5 arcsec diameter fiber given atmospheric seeing
 MEAN_FIBER_X               float32
 MEAN_FIBER_Y               float32
-========================== ======= ===== ===========
+========================== ======= ============ ===============================================================================================================================
 
 .. [1] Optional
 
@@ -258,36 +258,36 @@ Required Data Table Columns
 
 .. rst-class:: columns
 
-===================== ======= ===== ===========
-Name                  Type    Units Description
-===================== ======= ===== ===========
-TARGETID              int64
-PRIORITY              int32
-SUBPRIORITY           float64
+===================== ======= ======== =======================================================================================================
+Name                  Type    Units    Description
+===================== ======= ======== =======================================================================================================
+TARGETID              int64            Unique DESI target ID
+PRIORITY              int32            Target current priority
+SUBPRIORITY           float64          Random subpriority [0-1) to break assignment ties
 NIGHT                 int32
-EXPID                 int32
-MJD                   float64
-TILEID                int32
-EXPTIME               float64
-PETAL_LOC             int16
-DEVICE_LOC            int32
-LOCATION              int64
+EXPID                 int32            DESI Exposure ID number
+MJD                   float64          Modified Julian Date when shutter was opened for this exposure
+TILEID                int32            Unique DESI tile ID
+EXPTIME               float64 s        Length of time shutter was open
+PETAL_LOC             int16            Petal location [0-9]
+DEVICE_LOC            int32            Device location on focal plane [0-523]
+LOCATION              int64            Location on the focal plane PETAL_LOC*1000 + DEVICE_LOC
 FIBER                 int32
-FIBERSTATUS           int32
-FIBERASSIGN_X         float32
-FIBERASSIGN_Y         float32
-LAMBDA_REF            float32
-PLATE_RA              float64
-PLATE_DEC             float64
-NUM_ITER              int64
-FIBER_X               float64
-FIBER_Y               float64
-DELTA_X               float64
-DELTA_Y               float64
-FIBER_RA              float64
-FIBER_DEC             float64
-PSF_TO_FIBER_SPECFLUX float64
-===================== ======= ===== ===========
+FIBERSTATUS           int32            Fiber status mask. 0=good
+FIBERASSIGN_X         float32 mm       Fiberassign expected CS5 X location on focal plane
+FIBERASSIGN_Y         float32 mm       Fiberassign expected CS5 Y location on focal plane
+LAMBDA_REF            float32 Angstrom Requested wavelength at which targets should be centered on fibers
+PLATE_RA              float64 deg      Right Ascension to be used by PlateMaker
+PLATE_DEC             float64 deg      Declination to be used by PlateMaker
+NUM_ITER              int64            Number of positioner iterations
+FIBER_X               float64 mm       CS5 X location requested by PlateMaker
+FIBER_Y               float64 mm       CS5 Y location requested by PlateMaker
+DELTA_X               float64 mm       CS5 X requested minus actual position
+DELTA_Y               float64 mm       CS5 Y requested minus actual position
+FIBER_RA              float64 deg      RA of actual fiber position
+FIBER_DEC             float64 deg      DEC of actual fiber position
+PSF_TO_FIBER_SPECFLUX float64          fraction of light from point-like source captured by 1.5 arcsec diameter fiber given atmospheric seeing
+===================== ======= ======== =======================================================================================================
 
 HDU4
 ----
@@ -315,43 +315,43 @@ Required Data Table Columns
 
 .. rst-class:: columns
 
-================= ======= ===== ===========
+================= ======= ===== ======================================
 Name              Type    Units Description
-================= ======= ===== ===========
-TARGETID          int64
+================= ======= ===== ======================================
+TARGETID          int64         Unique DESI target ID
 TSNR2_GPBDARK_B   float32
-TSNR2_ELG_B       float32
+TSNR2_ELG_B       float32       ELG B template (S/N)^2
 TSNR2_GPBBRIGHT_B float32
-TSNR2_LYA_B       float32
-TSNR2_BGS_B       float32
+TSNR2_LYA_B       float32       LYA B template (S/N)^2
+TSNR2_BGS_B       float32       BGS B template (S/N)^2
 TSNR2_GPBBACKUP_B float32
-TSNR2_QSO_B       float32
-TSNR2_LRG_B       float32
+TSNR2_QSO_B       float32       QSO B template (S/N)^2
+TSNR2_LRG_B       float32       LRG B template (S/N)^2
 TSNR2_GPBDARK_R   float32
-TSNR2_ELG_R       float32
+TSNR2_ELG_R       float32       ELG R template (S/N)^2
 TSNR2_GPBBRIGHT_R float32
-TSNR2_LYA_R       float32
-TSNR2_BGS_R       float32
+TSNR2_LYA_R       float32       LYA R template (S/N)^2
+TSNR2_BGS_R       float32       BGS R template (S/N)^2
 TSNR2_GPBBACKUP_R float32
-TSNR2_QSO_R       float32
-TSNR2_LRG_R       float32
+TSNR2_QSO_R       float32       QSO R template (S/N)^2
+TSNR2_LRG_R       float32       LRG R template (S/N)^2
 TSNR2_GPBDARK_Z   float32
-TSNR2_ELG_Z       float32
+TSNR2_ELG_Z       float32       ELG Z template (S/N)^2
 TSNR2_GPBBRIGHT_Z float32
-TSNR2_LYA_Z       float32
-TSNR2_BGS_Z       float32
+TSNR2_LYA_Z       float32       LYA Z template (S/N)^2
+TSNR2_BGS_Z       float32       BGS Z template (S/N)^2
 TSNR2_GPBBACKUP_Z float32
-TSNR2_QSO_Z       float32
-TSNR2_LRG_Z       float32
+TSNR2_QSO_Z       float32       QSO Z template (S/N)^2
+TSNR2_LRG_Z       float32       LRG Z template (S/N)^2
 TSNR2_GPBDARK     float32
-TSNR2_ELG         float32
+TSNR2_ELG         float32       ELG template (S/N)^2 summed over B,R,Z
 TSNR2_GPBBRIGHT   float32
-TSNR2_LYA         float32
-TSNR2_BGS         float32
+TSNR2_LYA         float32       LYA template (S/N)^2 summed over B,R,Z
+TSNR2_BGS         float32       BGS template (S/N)^2 summed over B,R,Z
 TSNR2_GPBBACKUP   float32
-TSNR2_QSO         float32
-TSNR2_LRG         float32
-================= ======= ===== ===========
+TSNR2_QSO         float32       QSO template (S/N)^2 summed over B,R,Z
+TSNR2_LRG         float32       LRG template (S/N)^2 summed over B,R,Z
+================= ======= ===== ======================================
 
 
 Notes and Examples

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/tiles/GROUPTYPE/TILEID/GROUPID/spectra-SPECTROGRAPH-TILEID-GROUPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/tiles/GROUPTYPE/TILEID/GROUPID/spectra-SPECTROGRAPH-TILEID-GROUPID.rst
@@ -145,93 +145,93 @@ for detailed descriptions of the columns.
 
 .. rst-class:: columns
 
-===================== ======= ===== ===========
-Name                  Type    Units Description
-===================== ======= ===== ===========
-TARGETID              int64
-PETAL_LOC             int16
-DEVICE_LOC            int32
-LOCATION              int64
+===================== ======= ============ =========================================================================================================================
+Name                  Type    Units        Description
+===================== ======= ============ =========================================================================================================================
+TARGETID              int64                Unique DESI target ID
+PETAL_LOC             int16                Petal location [0-9]
+DEVICE_LOC            int32                Device location on focal plane [0-523]
+LOCATION              int64                Location on the focal plane PETAL_LOC*1000 + DEVICE_LOC
 FIBER                 int32
-FIBERSTATUS           int32
-TARGET_RA             float64
-TARGET_DEC            float64
-PMRA                  float32
-PMDEC                 float32
-REF_EPOCH             float32
-LAMBDA_REF            float32
-FA_TARGET             int64
-FA_TYPE               binary
-OBJTYPE               char[3]
-FIBERASSIGN_X         float32
-FIBERASSIGN_Y         float32
-PRIORITY              int32
-SUBPRIORITY           float64
-OBSCONDITIONS         int32
-RELEASE               int16
-BRICKID               int32
-BRICK_OBJID           int32
-MORPHTYPE             char[4]
-FLUX_G                float32
-FLUX_R                float32
-FLUX_Z                float32
-FLUX_IVAR_G           float32
-FLUX_IVAR_R           float32
-FLUX_IVAR_Z           float32
-MASKBITS              int16
-REF_ID                int64
-REF_CAT               char[2]
-GAIA_PHOT_G_MEAN_MAG  float32
-GAIA_PHOT_BP_MEAN_MAG float32
-GAIA_PHOT_RP_MEAN_MAG float32
-PARALLAX              float32
-BRICKNAME             char[8]
-EBV                   float32
-FLUX_W1               float32
-FLUX_W2               float32
-FLUX_IVAR_W1          float32
-FLUX_IVAR_W2          float32
-FIBERFLUX_G           float32
-FIBERFLUX_R           float32
-FIBERFLUX_Z           float32
-FIBERTOTFLUX_G        float32
-FIBERTOTFLUX_R        float32
-FIBERTOTFLUX_Z        float32
-SERSIC                float32
-SHAPE_R               float32
-SHAPE_E1              float32
-SHAPE_E2              float32
-PHOTSYS               char[1]
-PRIORITY_INIT         int64
-NUMOBS_INIT           int64
-SV1_DESI_TARGET [1]_  int64
-SV1_BGS_TARGET [1]_   int64
-SV1_MWS_TARGET [1]_   int64
-SV1_SCND_TARGET [1]_  int64
-SV3_DESI_TARGET [1]_  int64
-SV3_BGS_TARGET [1]_   int64
-SV3_MWS_TARGET [1]_   int64
-SV3_SCND_TARGET [1]_  int64
-DESI_TARGET           int64
-BGS_TARGET            int64
-MWS_TARGET            int64
-SCND_TARGET [1]_      int64
-PLATE_RA              float64
-PLATE_DEC             float64
-NUM_ITER              int64
-FIBER_X               float64
-FIBER_Y               float64
-DELTA_X               float64
-DELTA_Y               float64
-FIBER_RA              float64
-FIBER_DEC             float64
-EXPTIME               float64
-PSF_TO_FIBER_SPECFLUX float64
+FIBERSTATUS           int32                Fiber status mask. 0=good
+TARGET_RA             float64 deg          Target right ascension
+TARGET_DEC            float64 deg          Target declination
+PMRA                  float32 mas yr^-1    proper motion in the +RA direction (already including cos(dec))
+PMDEC                 float32 mas yr^-1    Proper motion in the +Dec direction
+REF_EPOCH             float32 yr           Reference epoch for Gaia/Tycho astrometry. Typically 2015.5 for Gaia
+LAMBDA_REF            float32 Angstrom     Requested wavelength at which targets should be centered on fibers
+FA_TARGET             int64                Targeting bit internally used by fiberassign (linked with FA_TYPE)
+FA_TYPE               binary               Fiberassign internal target type (science, standard, sky, safe, suppsky)
+OBJTYPE               char[3]              Object type: TGT, SKY, NON, BAD
+FIBERASSIGN_X         float32 mm           Fiberassign expected CS5 X location on focal plane
+FIBERASSIGN_Y         float32 mm           Fiberassign expected CS5 Y location on focal plane
+PRIORITY              int32                Target current priority
+SUBPRIORITY           float64              Random subpriority [0-1) to break assignment ties
+OBSCONDITIONS         int32                Bitmask of allowed observing conditions
+RELEASE               int16                Imaging surveys release ID
+BRICKID               int32                Brick ID from tractor input
+BRICK_OBJID           int32                Imaging Surveys OBJID on that brick
+MORPHTYPE             char[4]              Imaging Surveys morphological type from Tractor
+FLUX_G                float32 nanomaggy    Flux in the Legacy Survey g-band (AB)
+FLUX_R                float32 nanomaggy    Flux in the Legacy Survey r-band (AB)
+FLUX_Z                float32 nanomaggy    Flux in the Legacy Survey z-band (AB)
+FLUX_IVAR_G           float32 nanomaggy^-2 Inverse variance of FLUX_G (AB)
+FLUX_IVAR_R           float32 nanomaggy^-2 Inverse variance of FLUX_R (AB)
+FLUX_IVAR_Z           float32 nanomaggy^-2 Inverse variance of FLUX_Z (AB)
+MASKBITS              int16                Bitwise mask from the imaging indicating potential issue or blending
+REF_ID                int64                Tyc1*1,000,000+Tyc2*10+Tyc3 for Tycho-2; “sourceid” for Gaia DR2
+REF_CAT               char[2]              Reference catalog source for star: “T2” for Tycho-2, “G2” for Gaia DR2, “L2” for the SGA, empty otherwise
+GAIA_PHOT_G_MEAN_MAG  float32 mag          Gaia G band magnitude
+GAIA_PHOT_BP_MEAN_MAG float32 mag          Gaia BP band magnitude
+GAIA_PHOT_RP_MEAN_MAG float32 mag          Gaia RP band magnitude
+PARALLAX              float32 mas          Reference catalog parallax
+BRICKNAME             char[8]              Brick name from tractor input
+EBV                   float32 mag          Galactic extinction E(B-V) reddening from SFD98
+FLUX_W1               float32 nanomaggy    WISE flux in W1 (AB)
+FLUX_W2               float32 nanomaggy    WISE flux in W2 (AB)
+FLUX_IVAR_W1          float32 nanomaggy^-2 Inverse variance of FLUX_W1 (AB)
+FLUX_IVAR_W2          float32 nanomaggy^-2 Inverse variance of FLUX_W2 (AB)
+FIBERFLUX_G           float32 nanomaggy    Predicted g-band flux within a fiber of diameter 1.5 arcsec from this object in 1 arcsec Gaussian seeing
+FIBERFLUX_R           float32 nanomaggy    Predicted r-band flux within a fiber of diameter 1.5 arcsec from this object in 1 arcsec Gaussian seeing
+FIBERFLUX_Z           float32 nanomaggy    Predicted z-band flux within a fiber of diameter 1.5 arcsec from this object in 1 arcsec Gaussian seeing
+FIBERTOTFLUX_G        float32 nanomaggy    Predicted g-band flux within a fiber of diameter 1.5 arcsec from all sources at this location in 1 arcsec Gaussian seeing
+FIBERTOTFLUX_R        float32 nanomaggy    Predicted r-band flux within a fiber of diameter 1.5 arcsec from all sources at this location in 1 arcsec Gaussian seeing
+FIBERTOTFLUX_Z        float32 nanomaggy    Predicted z-band flux within a fiber of diameter 1.5 arcsec from all sources at this location in 1 arcsec Gaussian seeing
+SERSIC                float32              Power-law index for the Sersic profile model (MORPHTYPE=”SER”)
+SHAPE_R               float32 arcsec       Half-light radius of galaxy model (&gt;0)
+SHAPE_E1              float32              Ellipticity component 1 of galaxy model for galaxy type MORPHTYPE
+SHAPE_E2              float32              Ellipticity component 2 of galaxy model for galaxy type MORPHTYPE
+PHOTSYS               char[1]              &#x27;N&#x27; for the MzLS/BASS photometric system, &#x27;S&#x27; for DECaLS
+PRIORITY_INIT         int64                Target initial priority from target selection bitmasks and OBSCONDITIONS
+NUMOBS_INIT           int64                Initial number of observations for target calculated across target selection bitmasks and OBSCONDITIONS
+SV1_DESI_TARGET [1]_  int64                DESI (dark time program) target selection bitmask for SV1
+SV1_BGS_TARGET [1]_   int64                BGS (bright time program) target selection bitmask for SV1
+SV1_MWS_TARGET [1]_   int64                MWS (bright time program) target selection bitmask for SV1
+SV1_SCND_TARGET [1]_  int64                Secondary target selection bitmask for SV1
+SV3_DESI_TARGET [1]_  int64                DESI (dark time program) target selection bitmask for SV3
+SV3_BGS_TARGET [1]_   int64                BGS (bright time program) target selection bitmask for SV3
+SV3_MWS_TARGET [1]_   int64                MWS (bright time program) target selection bitmask for SV3
+SV3_SCND_TARGET [1]_  int64                Secondary target selection bitmask for SV3
+DESI_TARGET           int64                DESI (dark time program) target selection bitmask
+BGS_TARGET            int64                BGS (Bright Galaxy Survey) target selection bitmask
+MWS_TARGET            int64                Milky Way Survey targeting bits
+SCND_TARGET [1]_      int64                Target selection bitmask for secondary programs
+PLATE_RA              float64 deg          Right Ascension to be used by PlateMaker
+PLATE_DEC             float64 deg          Declination to be used by PlateMaker
+NUM_ITER              int64                Number of positioner iterations
+FIBER_X               float64 mm           CS5 X location requested by PlateMaker
+FIBER_Y               float64 mm           CS5 Y location requested by PlateMaker
+DELTA_X               float64 mm           CS5 X requested minus actual position
+DELTA_Y               float64 mm           CS5 Y requested minus actual position
+FIBER_RA              float64 deg          RA of actual fiber position
+FIBER_DEC             float64 deg          DEC of actual fiber position
+EXPTIME               float64 s            Length of time shutter was open
+PSF_TO_FIBER_SPECFLUX float64              fraction of light from point-like source captured by 1.5 arcsec diameter fiber given atmospheric seeing
 NIGHT                 int32
-EXPID                 int32
-MJD                   float64
-TILEID                int32
-===================== ======= ===== ===========
+EXPID                 int32                DESI Exposure ID number
+MJD                   float64              Modified Julian Date when shutter was opened for this exposure
+TILEID                int32                Unique DESI tile ID
+===================== ======= ============ =========================================================================================================================
 
 .. [1] Optional
 
@@ -267,10 +267,10 @@ documentation for details about the columns.
 
 .. rst-class:: columns
 
-===================== ======= ===== ===================
+===================== ======= ===== ======================
 Name                  Type    Units Description
-===================== ======= ===== ===================
-TARGETID              int64         Unique target identifer
+===================== ======= ===== ======================
+TARGETID              int64         Unique DESI target ID
 SUM_RAW_COUNT_B       float64
 MEDIAN_RAW_COUNT_B    float64
 MEDIAN_RAW_SNR_B      float64
@@ -284,13 +284,13 @@ SUM_CALIB_COUNT_B     float64
 MEDIAN_CALIB_COUNT_B  float64
 MEDIAN_CALIB_SNR_B    float64
 TSNR2_GPBDARK_B       float64
-TSNR2_ELG_B           float64
+TSNR2_ELG_B           float64       ELG B template (S/N)^2
 TSNR2_GPBBRIGHT_B     float64
-TSNR2_LYA_B           float64
-TSNR2_BGS_B           float64
+TSNR2_LYA_B           float64       LYA B template (S/N)^2
+TSNR2_BGS_B           float64       BGS B template (S/N)^2
 TSNR2_GPBBACKUP_B     float64
-TSNR2_QSO_B           float64
-TSNR2_LRG_B           float64
+TSNR2_QSO_B           float64       QSO B template (S/N)^2
+TSNR2_LRG_B           float64       LRG B template (S/N)^2
 SUM_RAW_COUNT_R       float64
 MEDIAN_RAW_COUNT_R    float64
 MEDIAN_RAW_SNR_R      float64
@@ -304,13 +304,13 @@ SUM_CALIB_COUNT_R     float64
 MEDIAN_CALIB_COUNT_R  float64
 MEDIAN_CALIB_SNR_R    float64
 TSNR2_GPBDARK_R       float64
-TSNR2_ELG_R           float64
+TSNR2_ELG_R           float64       ELG R template (S/N)^2
 TSNR2_GPBBRIGHT_R     float64
-TSNR2_LYA_R           float64
-TSNR2_BGS_R           float64
+TSNR2_LYA_R           float64       LYA R template (S/N)^2
+TSNR2_BGS_R           float64       BGS R template (S/N)^2
 TSNR2_GPBBACKUP_R     float64
-TSNR2_QSO_R           float64
-TSNR2_LRG_R           float64
+TSNR2_QSO_R           float64       QSO R template (S/N)^2
+TSNR2_LRG_R           float64       LRG R template (S/N)^2
 SUM_RAW_COUNT_Z       float64
 MEDIAN_RAW_COUNT_Z    float64
 MEDIAN_RAW_SNR_Z      float64
@@ -324,14 +324,14 @@ SUM_CALIB_COUNT_Z     float64
 MEDIAN_CALIB_COUNT_Z  float64
 MEDIAN_CALIB_SNR_Z    float64
 TSNR2_GPBDARK_Z       float64
-TSNR2_ELG_Z           float64
+TSNR2_ELG_Z           float64       ELG Z template (S/N)^2
 TSNR2_GPBBRIGHT_Z     float64
-TSNR2_LYA_Z           float64
-TSNR2_BGS_Z           float64
+TSNR2_LYA_Z           float64       LYA Z template (S/N)^2
+TSNR2_BGS_Z           float64       BGS Z template (S/N)^2
 TSNR2_GPBBACKUP_Z     float64
-TSNR2_QSO_Z           float64
-TSNR2_LRG_Z           float64
-===================== ======= ===== ===================
+TSNR2_QSO_Z           float64       QSO Z template (S/N)^2
+TSNR2_LRG_Z           float64       LRG Z template (S/N)^2
+===================== ======= ===== ======================
 
 HDU03
 -----

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/tiles/GROUPTYPE/TILEID/GROUPID/tile-qa-TILEID-GROUPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/tiles/GROUPTYPE/TILEID/GROUPID/tile-qa-TILEID-GROUPID.rst
@@ -95,32 +95,32 @@ Required Data Table Columns
 
 .. rst-class:: columns
 
-============= ======= ===== ===========
+============= ======= ===== =========================================================================================================
 Name          Type    Units Description
-============= ======= ===== ===========
-TARGETID      int64         Unique target ID
+============= ======= ===== =========================================================================================================
+TARGETID      int64         Unique DESI target ID
 PETAL_LOC     int16         Petal location [0-9]
 DEVICE_LOC    int32         Device location on focal plane [0-523]
 LOCATION      int64         Location on the focal plane PETAL_LOC*1000 + DEVICE_LOC
 FIBER         int32         Fiber ID on the CCDs [0-4999]
-TARGET_RA     float64 deg   Target Right Ascension
-TARGET_DEC    float64 deg   Target Declination
+TARGET_RA     float64 deg   Target right ascension
+TARGET_DEC    float64 deg   Target declination
 MEAN_FIBER_X  float32 mm    Mean (over exposures) fiber CS5 X location on focal plane
 MEAN_FIBER_Y  float32 mm    Mean (over exposures) fiber CS5 Y location on focal plane
-MEAN_DELTA_X  float32 mm    Mean (over exposures) fiber difference between measured and requested CS5 X location on focal plane
-MEAN_DELTA_Y  float32 mm    Mean (over exposures) fiber difference between measured and requested CS5 Y location on focal plane
+MEAN_DELTA_X  float32 mm    Mean (over exposures) fiber difference requested - actual CS5 X location on focal plane
+MEAN_DELTA_Y  float32 mm    Mean (over exposures) fiber difference requested - actual CS5 Y location on focal plane
 RMS_DELTA_X   float32 mm    RMS (over exposures) of the fiber difference between measured and requested CS5 X location on focal plane
 RMS_DELTA_Y   float32 mm    RMS (over exposures) of the fiber difference between measured and requested CS5 Y location on focal plane
-DESI_TARGET   int64         Dark survey + calibration bitmask
-BGS_TARGET    int64         Bright Galaxy Survey bitmask
-EBV           float32 mag   Galactic extinction E(B-V) reddening
-TSNR2_LRG     float64       LRG Template-based squared signal-to-noise ratio
-Z             float64       Spectroscopic redshift (from the redrock file)
-SPECTYPE      char[6]       Spectroscopic type (from the redrock file)
-DELTACHI2     float64       Chi2 difference between the first- and second best redshifts (from the redrock file)
+DESI_TARGET   int64         DESI (dark time program) target selection bitmask
+BGS_TARGET    int64         BGS (Bright Galaxy Survey) target selection bitmask
+EBV           float32 mag   Galactic extinction E(B-V) reddening from SFD98
+TSNR2_LRG     float64       LRG template (S/N)^2 summed over B,R,Z
+Z             float64       Redshift measured by Redrock
+SPECTYPE      char[6]       Spectral type of Redrock best fit template (e.g. GALAXY, QSO, STAR)
+DELTACHI2     float64       chi2 difference between first- and second-best redrock template fits
 QAFIBERSTATUS int32         Fiber status bitmask, inflated with further QA diagnoses
-EFFTIME_SPEC  float32 s     Spectroscopic effective time, based on template-based squared signal-to-noise ratio
-============= ======= ===== ===========
+EFFTIME_SPEC  float32 s     Effective exposure time for nominal conditions derived from the TSNR2 fits to the spectroscopy
+============= ======= ===== =========================================================================================================
 
 HDU2
 ----
@@ -154,9 +154,9 @@ Required Data Table Columns
 
 .. rst-class:: columns
 
-============== ======= ===== ===========
+============== ======= ===== ==============================================================================================
 Name           Type    Units Description
-============== ======= ===== ===========
+============== ======= ===== ==============================================================================================
 PETAL_LOC      int16         Petal location [0-9]
 WORSTREADNOISE float32       Mean of the per-exposure WORSREADNOISE
 NGOODPOS       float32       Mean of the per-exposure NGOODPOS
@@ -173,8 +173,8 @@ ZSKYCHI2PDF    float32       Mean of the per-exposure ZSKYCHI2PDF
 BTHRUFRAC      float32       Mean of the per-exposure BTHRUFRAC
 RTHRUFRAC      float32       Mean of the per-exposure RTHRUFRAC
 ZTHRUFRAC      float32       Mean of the per-exposure ZTHRUFRAC
-EFFTIME_SPEC   float32 s     Median of the EFFTIME_SPEC values for all good fibers (for all exposures) from that petal
-============== ======= ===== ===========
+EFFTIME_SPEC   float32 s     Median effective exposure time for nominal conditions derived from the TSNR2 fits to the spectroscopy
+============== ======= ===== ==============================================================================================
 
 .. [1] Optional
 

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/tiles/GROUPTYPE/TILEID/GROUPID/zmtl-SPECTROGRAPH-TILEID-GROUPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/tiles/GROUPTYPE/TILEID/GROUPID/zmtl-SPECTROGRAPH-TILEID-GROUPID.rst
@@ -68,34 +68,34 @@ Required Data Table Columns
 
 .. rst-class:: columns
 
-==================== ======= ===== ===================
+==================== ======= ===== ====================================================================
 Name                 Type    Units Description
-==================== ======= ===== ===================
-RA                   float64 deg   Right ascension
-DEC                  float64 deg   Declination
-TARGETID             int64         Unique targeting ID
-SV1_DESI_TARGET [1]_ int64         DESI (dark time program) target selection bitmask (sv1 phase of DESI Survey Validation)
-SV1_BGS_TARGET [1]_  int64         BGS (bright time program) target selection bitmask (sv1 phase of DESI Survey Validation)
-SV1_MWS_TARGET [1]_  int64         MWS (bright time program) target selection bitmask (sv1 phase of DESI Survey Validation)
-SV1_SCND_TARGET [1]_ int64         SCND (secondary program) target selection bitmask (sv1 phase of DESI Survey Validation)
-SV3_DESI_TARGET [1]_ int64         DESI (dark time program) target selection bitmask (sv3 phase of DESI Survey Validation)
-SV3_BGS_TARGET [1]_  int64         BGS (bright time program) target selection bitmask (sv3 phase of DESI Survey Validation)
-SV3_MWS_TARGET [1]_  int64         MWS (bright time program) target selection bitmask (sv3 phase of DESI Survey Validation)
-SV3_SCND_TARGET [1]_ int64         SCND (secondary program) target selection bitmask (sv3 phase of DESI Survey Validation)
+==================== ======= ===== ====================================================================
+RA                   float64 deg   Target Right Ascension
+DEC                  float64 deg   Target declination
+TARGETID             int64         Unique DESI target ID
+SV1_DESI_TARGET [1]_ int64         DESI (dark time program) target selection bitmask for SV1
+SV1_BGS_TARGET [1]_  int64         BGS (bright time program) target selection bitmask for SV1
+SV1_MWS_TARGET [1]_  int64         MWS (bright time program) target selection bitmask for SV1
+SV1_SCND_TARGET [1]_ int64         Secondary target selection bitmask for SV1
+SV3_DESI_TARGET [1]_ int64         DESI (dark time program) target selection bitmask for SV3
+SV3_BGS_TARGET [1]_  int64         BGS (bright time program) target selection bitmask for SV3
+SV3_MWS_TARGET [1]_  int64         MWS (bright time program) target selection bitmask for SV3
+SV3_SCND_TARGET [1]_ int64         Secondary target selection bitmask for SV3
 DESI_TARGET [1]_     int64         DESI (dark time program) target selection bitmask
-BGS_TARGET [1]_      int64         BGS (bright time program) target selection bitmask
-MWS_TARGET [1]_      int64         MWS (bright time program) target selection bitmask
-SCND_TARGET  [1]_    int64         SCND (secondary program) target selection bitmask
-Z                    float64       Redshift from ``Redrock``
-ZWARN                int64         Redshift warning bimask
-SPECTYPE             char[6]       Spectroscopic classification from ``Redrock``
-DELTACHI2            float64       Chi-squared difference between the first- and second-best redshifts from ``Redrock``
+BGS_TARGET [1]_      int64         BGS (Bright Galaxy Survey) target selection bitmask
+MWS_TARGET [1]_      int64         Milky Way Survey targeting bits
+SCND_TARGET  [1]_    int64         Target selection bitmask for secondary programs
+Z                    float64       Redshift measured by Redrock
+ZWARN                int64         Redshift warning bitmask from Redrock, plus DESI-specific bits set
+SPECTYPE             char[6]       Spectral type of Redrock best fit template (e.g. GALAXY, QSO, STAR)
+DELTACHI2            float64       chi2 difference between first- and second-best redrock template fits
 NUMOBS               int32         Number of spectroscopic observations (on this specific, single tile)
-ZTILEID              int32         Unique tile ID (identical to ``TILEID``)
-Z_QN                 float64       Redshift from `QuasarNET`_
-Z_QN_CONF            float64       Redshift confidence from `QuasarNET`_
-IS_QSO_QN            int16         Spectroscopic classification	from `QuasarNET`_ (1 for a quasar)
-==================== ======= ===== ===================
+ZTILEID              int32         ID of tile that most recently updated target&#x27;s state
+Z_QN                 float64       Redshift measured by QuasarNET
+Z_QN_CONF            float64       Redshift confidence from QuasarNET
+IS_QSO_QN            int16         Spectroscopic classification from QuasarNET (1 for a quasar)
+==================== ======= ===== ====================================================================
 
 .. [1] Only `either` the four ``SV1``, ``SV3`` `or` Main Survey columns will be present. ``TARGET``
        bitmask columns are preceded by the survey ``PHASE`` except in the case of Main Survey files
@@ -109,6 +109,8 @@ See the DESI Survey Operations paper (Schlafly et al., in preparation) for
 details of how the quantities in the ``zmtl`` files are used to update the
 observational state of a target in the MTL ledgers.
 
+For more information, see `QuasarNET`_ for QuasarNET and
+`SQUEzE`_ for SQUEzE.
 
 .. _`QuasarNET`: https://ui.adsabs.harvard.edu/abs/2018arXiv180809955B/abstract
 .. _`SQUEzE`: https://ui.adsabs.harvard.edu/abs/2020MNRAS.496.4931P/abstract

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,8 @@ desidatamodel Change Log
 22.5 (unreleased)
 -----------------
 
+* Update column descriptions for tile-based spectra/redshift/afterburner files
+  (PR `#145`_).
 * Update column descriptions from a master list of columns (PR `#144`_).
 * Update spectra and coadd text with additional examples (PR `#143`_).
 * Add links to maskbit definitions (PR `#139`_).
@@ -34,6 +36,7 @@ desidatamodel Change Log
 .. _`#139`: https://github.com/desihub/desidatamodel/pull/139
 .. _`#143`: https://github.com/desihub/desidatamodel/pull/143
 .. _`#144`: https://github.com/desihub/desidatamodel/pull/144
+.. _`#145`: https://github.com/desihub/desidatamodel/pull/145
 
 22.2 (2022-05-31)
 -----------------

--- a/py/desidatamodel/data/column_descriptions.csv
+++ b/py/desidatamodel/data/column_descriptions.csv
@@ -23,12 +23,12 @@ COADD_NUMTILE,int16,,Number of tiles in coadd
 COEFF,float64[10],,Redrock template coefficients
 COMP_TILE,,,Assignment completeness for all targets of this type with the same value for TILES
 DCHISQ,float32[5],,Difference in chi-squared between Tractor model fits
-DEC,float64,deg,Declination
+DEC,float64,deg,Target declination
 DEC_IVAR,float32,deg^-2,"Inverse variance of DEC, excluding astrometric calibration errors"
 DELTA_CHI2_MGII,,,chi2 diff between redrock model fit and MgII fit
 DELTA_X,float64,mm,CS5 X requested minus actual position
 DELTA_Y,float64,mm,CS5 Y requested minus actual position
-DELTACHI2,float64,,Delta-chi-squared for template fit from Redrock
+DELTACHI2,float64,,chi2 difference between first- and second-best redrock template fits
 DESI_TARGET,int64,,DESI (dark time program) target selection bitmask
 DEVICE_LOC,int32,,Device location on focal plane [0-523]
 DEVICE_TYPE,,,Device type
@@ -186,14 +186,14 @@ NOBS_Z,int16,,Number of images for central pixel in z-band
 NPIXELS,int64,,
 NTILE,,,Number of tiles target was available on
 NUM_ITER,int64,,Number of positioner iterations
-NUMOBS,int64,,Number of times target has been observed
+NUMOBS,int64,,"Number of spectroscopic observations (on this specific, single tile)"
 NUMOBS_INIT,int64,,Initial number of observations for target calculated across target selection bitmasks and OBSCONDITIONS
 NUMOBS_MORE,int64,,Number of additional observations needed
 NZ,,,"The comoving number density of the tracer at the given redshift, in units (h/Mpc)^3, assuming complete sample"
 o2c,,,The criteria for assessing strength of OII emission for ELG observations
 OBJID,int32,,Imaging Surveys OBJID on that brick (renamed BRICK_OBJID)
 OBJTYPE,char[3],,"Object type: TGT, SKY, NON, BAD"
-OBSCONDITIONS,int32,,Bit-coded of allowed observing conditions
+OBSCONDITIONS,int32,,Bitmask of allowed observing conditions
 OII_CHI2,float32,,Reduced chi2 of the fit for the [OII] doublet
 OII_CONT,float32,10**-17 erg/(s cm2 Angstrom),Continuum used for the fitting (fixed value) for the [OII] doublet
 OII_CONT_IVAR,float32,10**+34 (s2 cm4 Angstrom2) / erg2,Inverse variance of the continuum for the [OII] doublet
@@ -224,9 +224,9 @@ PETAL_LOC,,,Petal location [0-9]
 PHOTSYS,char[1],,"'N' for the MzLS/BASS photometric system, 'S' for DECaLS"
 PLATE_DEC,float64,deg,Declination to be used by PlateMaker
 PLATE_RA,float64,deg,Right Ascension to be used by PlateMaker
-PMDEC,float32,mas yr^-1,Reference catalog proper motion in the Dec direction
+PMDEC,float32,mas yr^-1,Proper motion in the +Dec direction
 PMDEC_IVAR,float32,yr^2 mas^-2,Inverse variance of PMDEC
-PMRA,float32,mas yr^-1,Reference catalog proper motion in the RA direction
+PMRA,float32,mas yr^-1,"proper motion in the +RA direction (already including cos(dec))"
 PMRA_IVAR,float32,yr^2 mas^-2,Inverse variance of PMRA
 PRIORITY,,,Target current priority
 PRIORITY_INIT,int64,,Target initial priority from target selection bitmasks and OBSCONDITIONS
@@ -242,7 +242,7 @@ PSFSIZE_R,float32,arcsec,Median PSF size evaluated at the BRICK_PRIMARY objects 
 PSFSIZE_Z,float32,arcsec,Median PSF size evaluated at the BRICK_PRIMARY objects in this brick in z-band
 PSF_TO_FIBER_SPECFLUX,float64,,fraction of light from point-like source captured by 1.5 arcsec diameter fiber given atmospheric seeing
 QSO_MASKBITS,,,
-RA,float64,deg,Right Ascension
+RA,float64,deg,Target Right Ascension
 RA_IVAR,float32,deg^-2,"Inverse variance of RA (no cosine term!), excluding astrometric calibration errors"
 REF_CAT,char[2],,"Reference catalog source for star: “T2” for Tycho-2, “G2” for Gaia DR2, “L2” for the SGA, empty otherwise"
 REF_ID,int64,,"Tyc1*1,000,000+Tyc2*10+Tyc3 for Tycho-2; “sourceid” for Gaia DR2"
@@ -276,11 +276,11 @@ SHAPE_R,float32,arcsec,Half-light radius of galaxy model (>0)
 SHAPE_R_IVAR,float32,arcsec^-2,Inverse variance of SHAPE_R
 SIGMA_MGII,float32,Angstrom,Fitted parameter SIGMA (linewidth) by MgII fitter (in angstrom?)
 sort,,,Number constructed to sort the table prior to cutting to unique TARGETID
-SPECTYPE,char[6],,Spectype from redrock file
+SPECTYPE,char[6],,"Spectral type of Redrock best fit template (e.g. GALAXY, QSO, STAR)"
 SPGRPVAL,int32,,Value by which spectra are grouped for a coadd (e.g. a YEARMMDD night)
 STD_FIBER_DEC,float32,arcsec,Standard deviation (over exposures) of DEC of actual fiber position
 STD_FIBER_RA,float32,arcsec,Standard deviation (over exposures) of RA of actual fiber position
-SUBPRIORITY,float64,,Random subpriority [0-1] to break assignment ties
+SUBPRIORITY,float64,,Random subpriority [0-1) to break assignment ties
 SUBTYPE,char[20],,Spectral subtype
 SURVEY,char[7],,Survey name
 SV_NSPEC,int32,,Number of coadded spectra for this TARGETID in SV (SV1+2+3)
@@ -363,5 +363,5 @@ ZERR,float64,,Redshift error from redrock
 ZERR_QF,,,
 ZPOSSLOC,,,True/False whether the location could have been assigned to the given target class
 ZTILEID,int32,,ID of tile that most recently updated target's state
-ZWARN,int64,,Redshift warning bitmask measured by Redrock
+ZWARN,int64,,Redshift warning bitmask from Redrock
 ZWARN_MTL,int64,,The ZWARN from the zmtl file (contains extra bits)

--- a/py/desidatamodel/data/column_descriptions.csv
+++ b/py/desidatamodel/data/column_descriptions.csv
@@ -7,12 +7,12 @@ BGS_TARGET,int64,,BGS (Bright Galaxy Survey) target selection bitmask
 BRICK_OBJID,int32,,Imaging Surveys OBJID on that brick
 BRICKID,int32,,Brick ID from tractor input
 BRICKNAME,char[8],,Brick name from tractor input
-C_CIII,,,Confidence line for CIII
-C_CIV,,,Confidence line for CIV
-C_Halpha,,,Confidence line for Halpha
-C_Hbeta,,,Confidence line for Hbeta
-C_LYA,,,"Confidence line for LYA, i.e. ~probability to be a QSO"
-C_MgII,,,Confidence line for MgII
+C_CIII,,,Confidence for CIII line
+C_CIV,,,Confidence for CIV line
+C_Halpha,,,Confidence for Halpha line
+C_Hbeta,,,Confidence for Hbeta line
+C_LYA,,,"Confidence for LyA line, i.e. ~probability to be a QSO"
+C_MgII,,,Confidence for MgII line
 CHI2,float64,,Best fit chi squared
 CMX_TARGET,int64,,Target selection bitmask for commissioning
 COADD_EXPTIME,float32,s,Summed exposure time for coadd
@@ -350,10 +350,10 @@ Z_CIII,float64,,Redshift estimated by QuasarNET with CIII line
 Z_CIV,float64,,Redshift estimated by QuasarNET with CIV line
 Z_Halpha,float64,,Redshift estimated by QuasarNET with Halpha line
 Z_Hbeta,float64,,Redshift estimated by QuasarNET with Hbeta line
-Z_LYA,float64,,Redshift estimated by QuasarNET with LYA line
+Z_LYA,float64,,Redshift estimated by QuasarNET with LyA line
 Z_MgII,float64,,Redshift estimated by QuasarNET with MgII line
 Z_not4clus,float64,,Redshift name changed after vetos are applied
-Z_QN,float64,,Redshift measured by QuasarNET
+Z_QN,float64,,Redshift measured by QuasarNET using line with highest confidence
 Z_QN_CONF,float64,,Redshift confidence from QuasarNET
 Z_QN_QF,float64,,
 Z_RR,float64,,Redshift collected from redrock file

--- a/py/desidatamodel/update.py
+++ b/py/desidatamodel/update.py
@@ -219,12 +219,26 @@ def main():
 
     import argparse
     parser = argparse.ArgumentParser()
-    parser.add_argument('-i', '--infile', help='Input model filename')
-    parser.add_argument('-o', '--outfile', help='Output model filename')
+    parser.add_argument('-i', '--infile', required=True,
+                        help='Input model filename')
+    parser.add_argument('-o', '--outfile',
+                        help='Output model filename')
+    parser.add_argument('--inplace', action='store_true',
+                        help="Update input file inplace, equivalent to specifying "
+                             "--outfile with same name as --infile")
     parser.add_argument('--force', action='store_true',
                         help="Update non-blank pre-existing entries that differ from "
                              "reference units and descriptions")
     args = parser.parse_args()
+
+    log = get_logger()
+
+    if args.inplace:
+        if args.outfile is not None:
+            raise ValueError("When using --inplace, don't specify --outfile")
+        args.outfile = args.infile
+    elif args.outfile is None:
+        log.info('Neither --inplace nor --outfile specified; will print changes but not write output')
 
     # Read input data model file
     with open(args.infile) as fp:


### PR DESCRIPTION
This is the next installment in updates to the data models in DESI_SPECTRO_REDUX/SPECPROD/tiles/GROUPTYPE/TILEID/GROUPID, with columns descriptions updated with
```
update_column_descriptions -i filename.rst [--inplace --force]
```
I first ran without `--inplace --force` to see what it would update, and then updated `py/desidatamodel/data/column_descriptions.csv` if I thought any pre-existing description was better than what we had in column_descriptions.csv.  I then reran with `--inplace --force` to do the actual updates.  Exception: I kept the zmtl ZWARN and ZTILED slightly different from the standard descriptions, since zmtl augments the ZWARN flags from redrock, and the standard ZTILEID description is for the mtl ledgers where there actually can be more than one tile, which doesn't apply to zmtl.

This PR also includes the new option `--inplace`, which is a convenience option equivalent to providing the same `--outfile` as `--infile` (i.e. so you only have to write the input filename once, and don't risk a cut-and-paste error or replacing one datamodel with another).

