### PR TITLE
RA/DEC in Barycentric ICRS, not J2000

### DIFF
--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/zcatalog/zpix-SURVEY-PROGRAM.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/zcatalog/zpix-SURVEY-PROGRAM.rst
@@ -104,8 +104,8 @@ SUBTYPE                    char[20]          label for field   9
 NCOEFF                     int64             label for field  10
 DELTACHI2                  float64           label for field  11
 COADD_FIBERSTATUS          int32             label for field  12
-TARGET_RA                  float64           Right ascension at equinox J2000
-TARGET_DEC                 float64           Declination at equinox J2000
+TARGET_RA                  float64           Barycentric Right Ascension in ICRS
+TARGET_DEC                 float64           Barycentric Declination in ICRS
 PMRA                       float32           Reference catalog proper motion in the RA direction
 PMDEC                      float32           Reference catalog proper motion in the Dec direction
 REF_EPOCH                  float32           Reference catalog reference epoch (*e.g.*, 2015.5 for Gaia_ DR2)

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/zcatalog/ztile-SURVEY-PROGRAM-GROUPTYPE.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/zcatalog/ztile-SURVEY-PROGRAM-GROUPTYPE.rst
@@ -107,8 +107,8 @@ DEVICE_LOC                 int32             label for field  13
 LOCATION                   int64             label for field  14
 FIBER                      int32             label for field  15
 COADD_FIBERSTATUS          int32             label for field  16
-TARGET_RA                  float64           Right ascension at equinox J2000
-TARGET_DEC                 float64           Declination at equinox J2000
+TARGET_RA                  float64           Barycentric Right Ascension in ICRS
+TARGET_DEC                 float64           Barycentric Declination in ICRS
 PMRA                       float32           Reference catalog proper motion in the RA direction
 PMDEC                      float32           Reference catalog proper motion in the Dec direction
 REF_EPOCH                  float32           Reference catalog reference epoch (*e.g.*, 2015.5 for Gaia_ DR2)

--- a/py/desidatamodel/data/column_descriptions.csv
+++ b/py/desidatamodel/data/column_descriptions.csv
@@ -31,7 +31,7 @@ COADD_NUMTILE,int16,,Number of tiles in coadd
 COEFF,float64[10],,Redrock template coefficients
 COMP_TILE,,,Assignment completeness for all targets of this type with the same value for TILES
 DCHISQ,float32[5],,Difference in chi-squared between Tractor model fits
-DEC,float64,deg,Target declination
+DEC,float64,deg,Barycentric declination in ICRS
 DEC_IVAR,float32,deg^-2,"Inverse variance of DEC, excluding astrometric calibration errors"
 DELTA_CHI2_MGII,,,chi2 diff between redrock model fit and MgII fit
 DELTA_X,float64,mm,CS5 X requested minus actual position
@@ -235,8 +235,8 @@ PARALLAX,float32,mas,Reference catalog parallax
 PARALLAX_IVAR,float32,mas^-2,Inverse variance of PARALLAX
 PETAL_LOC,,,Petal location [0-9]
 PHOTSYS,char[1],,"'N' for the MzLS/BASS photometric system, 'S' for DECaLS"
-PLATE_DEC,float64,deg,Declination to be used by PlateMaker
-PLATE_RA,float64,deg,Right Ascension to be used by PlateMaker
+PLATE_DEC,float64,deg,Barycentric Declination in ICRS to be used by PlateMaker
+PLATE_RA,float64,deg,Barycentric Right Ascension in ICRS to be used by PlateMaker
 PMDEC,float32,mas yr^-1,Proper motion in the +Dec direction
 PMDEC_IVAR,float32,yr^2 mas^-2,Inverse variance of PMDEC
 PMRA,float32,mas yr^-1,"proper motion in the +RA direction (already including cos(dec))"
@@ -255,7 +255,7 @@ PSFSIZE_G,float32,arcsec,Median PSF size evaluated at the BRICK_PRIMARY objects 
 PSFSIZE_R,float32,arcsec,Median PSF size evaluated at the BRICK_PRIMARY objects in this brick in r-band
 PSFSIZE_Z,float32,arcsec,Median PSF size evaluated at the BRICK_PRIMARY objects in this brick in z-band
 PSF_TO_FIBER_SPECFLUX,float64,,fraction of light from point-like source captured by 1.5 arcsec diameter fiber given atmospheric seeing
-RA,float64,deg,Target Right Ascension
+RA,float64,deg,Barycentric Right Ascension in ICRS
 RA_IVAR,float32,deg^-2,"Inverse variance of RA (no cosine term!), excluding astrometric calibration errors"
 REF_CAT,char[2],,"Reference catalog source for star: “T2” for Tycho-2, “G2” for Gaia DR2, “L2” for the SGA, empty otherwise"
 REF_ID,int64,,"Tyc1*1,000,000+Tyc2*10+Tyc3 for Tycho-2; “sourceid” for Gaia DR2"
@@ -313,16 +313,16 @@ SV3_BGS_TARGET,int64,,BGS (bright time program) target selection bitmask for SV3
 SV3_DESI_TARGET,int64,,DESI (dark time program) target selection bitmask for SV3
 SV3_MWS_TARGET,int64,,MWS (bright time program) target selection bitmask for SV3
 SV3_SCND_TARGET,int64,,Secondary target selection bitmask for SV3
-TARGET_DEC,float64,deg,Target declination
-TARGET_RA,float64,deg,Target right ascension
+TARGET_DEC,float64,deg,Barycentric declination in ICRS
+TARGET_RA,float64,deg,Barycentric right ascension in ICRS
 TARGET_STATE,,,Combination of target class and its current observational state
 TARGETID,int64,,Unique DESI target ID
-TILEDEC,float64,deg,Declination of the center of a tile
+TILEDEC,float64,deg,Barycentric declination of tile center in ICRS
 TILEID,int32,,Unique DESI tile ID
 TILELOCID,,,Is 10000*TILEID+LOCATION
 TILELOCID_ASSIGNED,,,0/1 for unassigned/assigned for TILELOCID in question (it could have been assigned to a different target)
 TILELOCIDS,,,"TILELOCIDs that the target was available for, separated by '-'"
-TILERA,float64,deg,Right Ascension (RA) of the center of a tile
+TILERA,float64,deg,Barycentric Right Ascension of tile center in ICRS
 TILES,str,,"TILEIDs of those tile, in string form separated by '-'"
 TIMESTAMP,str,s,UTC/ISO time at which the target state was updated
 TSNR2_BGS,float32,,"BGS template (S/N)^2 summed over B,R,Z"

--- a/py/desidatamodel/test/test_update.py
+++ b/py/desidatamodel/test/test_update.py
@@ -66,11 +66,11 @@ Final text
         for line in output_lines[22:]:
             # gained units and descriptions
             if line.startswith('TARGET_RA'):
-                self.assertEqual(line, 'TARGET_RA       float64 deg       Target right ascension')
+                self.assertEqual(line, 'TARGET_RA       float64 deg       Barycentric right ascension in ICRS')
 
             # Footnote was preserved while adding units and description
             if line.startswith('TARGET_DEC'):
-                self.assertEqual(line, 'TARGET_DEC [1]_ float64 deg       Target declination')
+                self.assertEqual(line, 'TARGET_DEC [1]_ float64 deg       Barycentric declination in ICRS')
 
             if line.startswith('FLUX_R'):
                 self.assertEqual(line, 'FLUX_R          float32 nanomaggy Flux in the Legacy Survey r-band (AB)')


### PR DESCRIPTION
This PR removes RA/DEC references to J2000, replacing them with more correct descriptions of barycentric ICRS.  I also updated the standard column description file so that future updates will use the more correct description.  I didn't change pre-existing descriptions that just said "Right Ascension" without mentioning J2000, since they are correct even if they are less complete than they could be (and we've got a lot of other more important EDR tasks on our plate).

fixes #147 