### PR TITLE
update spectra descriptions

### DIFF
--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/cframe-CAMERA-EXPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/cframe-CAMERA-EXPID.rst
@@ -1340,94 +1340,94 @@ Required Data Table Columns
 
 .. rst-class:: columns
 
-===================== ======= ===== ==============================
-Name                  Type    Units Description
-===================== ======= ===== ==============================
-TARGETID              int64         Unique target ID
-PETAL_LOC             int16         Focal plane petal location 0-9
-DEVICE_LOC            int32         Device location 0-5xx
-LOCATION              int64         1000*PETAL_LOC + DEVICE_LOC
-FIBER                 int32         Fiber number 0-4999
-FIBERSTATUS           int32         Fiber status mask; 0=good
-TARGET_RA             float64
-TARGET_DEC            float64
-PMRA                  float32
-PMDEC                 float32
-REF_EPOCH             float32
-LAMBDA_REF            float32
-FA_TARGET             int64
-FA_TYPE               binary
-OBJTYPE               char[3]
-FIBERASSIGN_X         float32
-FIBERASSIGN_Y         float32
-PRIORITY              int32
-SUBPRIORITY           float64
-OBSCONDITIONS         int32
-RELEASE               int16
-BRICKID               int32
-BRICK_OBJID           int32
-MORPHTYPE             char[4]
-FLUX_G                float32
-FLUX_R                float32
-FLUX_Z                float32
-FLUX_IVAR_G           float32
-FLUX_IVAR_R           float32
-FLUX_IVAR_Z           float32
-MASKBITS              int16
-REF_ID                int64
-REF_CAT               char[2]
-GAIA_PHOT_G_MEAN_MAG  float32
-GAIA_PHOT_BP_MEAN_MAG float32
-GAIA_PHOT_RP_MEAN_MAG float32
-PARALLAX              float32
-BRICKNAME             char[8]
-EBV                   float32
-FLUX_W1               float32
-FLUX_W2               float32
-FLUX_IVAR_W1          float32
-FLUX_IVAR_W2          float32
-FIBERFLUX_G           float32
-FIBERFLUX_R           float32
-FIBERFLUX_Z           float32
-FIBERTOTFLUX_G        float32
-FIBERTOTFLUX_R        float32
-FIBERTOTFLUX_Z        float32
-SERSIC                float32
-SHAPE_R               float32
-SHAPE_E1              float32
-SHAPE_E2              float32
-PHOTSYS               char[1]
-PRIORITY_INIT         int64
-NUMOBS_INIT           int64
-SV1_DESI_TARGET [1]_  int64
-SV1_BGS_TARGET [1]_   int64
-SV1_MWS_TARGET [1]_   int64
-SV1_SCND_TARGET [1]_  int64
-DESI_TARGET           int64
-BGS_TARGET            int64
-MWS_TARGET            int64
-SCND_TARGET [1]_      int64
-PLATE_RA              float64
-PLATE_DEC             float64
-NUM_ITER              int64
-FIBER_X               float64
-FIBER_Y               float64
-DELTA_X               float64
-DELTA_Y               float64
-FIBER_RA              float64
-FIBER_DEC             float64
-EXPTIME               float64
-PSF_TO_FIBER_SPECFLUX float64
-SV3_MWS_TARGET [1]_   int64
-SV3_SCND_TARGET [1]_  int64
-SV3_DESI_TARGET [1]_  int64
-SV3_BGS_TARGET [1]_   int64
-SV2_DESI_TARGET [1]_  int64
-SV2_BGS_TARGET [1]_   int64
-SV2_MWS_TARGET [1]_   int64
-SV2_SCND_TARGET [1]_  int64
-CMX_TARGET [1]_       int64
-===================== ======= ===== ==============================
+===================== ======= ============ =========================================================================================================================
+Name                  Type    Units        Description
+===================== ======= ============ =========================================================================================================================
+TARGETID              int64                Unique DESI target ID
+PETAL_LOC             int16                Petal location [0-9]
+DEVICE_LOC            int32                Device location on focal plane [0-523]
+LOCATION              int64                Location on the focal plane PETAL_LOC*1000 + DEVICE_LOC
+FIBER                 int32                Fiber ID on the CCDs [0-4999]
+FIBERSTATUS           int32                Fiber status mask. 0=good
+TARGET_RA             float64 deg          Barycentric right ascension in ICRS
+TARGET_DEC            float64 deg          Barycentric declination in ICRS
+PMRA                  float32 mas yr^-1    proper motion in the +RA direction (already including cos(dec))
+PMDEC                 float32 mas yr^-1    Proper motion in the +Dec direction
+REF_EPOCH             float32 yr           Reference epoch for Gaia/Tycho astrometry. Typically 2015.5 for Gaia
+LAMBDA_REF            float32 Angstrom     Requested wavelength at which targets should be centered on fibers
+FA_TARGET             int64                Targeting bit internally used by fiberassign (linked with FA_TYPE)
+FA_TYPE               binary               Fiberassign internal target type (science, standard, sky, safe, suppsky)
+OBJTYPE               char[3]              Object type: TGT, SKY, NON, BAD
+FIBERASSIGN_X         float32 mm           Fiberassign expected CS5 X location on focal plane
+FIBERASSIGN_Y         float32 mm           Fiberassign expected CS5 Y location on focal plane
+PRIORITY              int32                Target current priority
+SUBPRIORITY           float64              Random subpriority [0-1) to break assignment ties
+OBSCONDITIONS         int32                Bitmask of allowed observing conditions
+RELEASE               int16                Imaging surveys release ID
+BRICKID               int32                Brick ID from tractor input
+BRICK_OBJID           int32                Imaging Surveys OBJID on that brick
+MORPHTYPE             char[4]              Imaging Surveys morphological type from Tractor
+FLUX_G                float32 nanomaggy    Flux in the Legacy Survey g-band (AB)
+FLUX_R                float32 nanomaggy    Flux in the Legacy Survey r-band (AB)
+FLUX_Z                float32 nanomaggy    Flux in the Legacy Survey z-band (AB)
+FLUX_IVAR_G           float32 nanomaggy^-2 Inverse variance of FLUX_G (AB)
+FLUX_IVAR_R           float32 nanomaggy^-2 Inverse variance of FLUX_R (AB)
+FLUX_IVAR_Z           float32 nanomaggy^-2 Inverse variance of FLUX_Z (AB)
+MASKBITS              int16                Bitwise mask from the imaging indicating potential issue or blending
+REF_ID                int64                Tyc1*1,000,000+Tyc2*10+Tyc3 for Tycho-2; “sourceid” for Gaia DR2
+REF_CAT               char[2]              Reference catalog source for star: “T2” for Tycho-2, “G2” for Gaia DR2, “L2” for the SGA, empty otherwise
+GAIA_PHOT_G_MEAN_MAG  float32 mag          Gaia G band magnitude
+GAIA_PHOT_BP_MEAN_MAG float32 mag          Gaia BP band magnitude
+GAIA_PHOT_RP_MEAN_MAG float32 mag          Gaia RP band magnitude
+PARALLAX              float32 mas          Reference catalog parallax
+BRICKNAME             char[8]              Brick name from tractor input
+EBV                   float32 mag          Galactic extinction E(B-V) reddening from SFD98
+FLUX_W1               float32 nanomaggy    WISE flux in W1 (AB)
+FLUX_W2               float32 nanomaggy    WISE flux in W2 (AB)
+FLUX_IVAR_W1          float32 nanomaggy^-2 Inverse variance of FLUX_W1 (AB)
+FLUX_IVAR_W2          float32 nanomaggy^-2 Inverse variance of FLUX_W2 (AB)
+FIBERFLUX_G           float32 nanomaggy    Predicted g-band flux within a fiber of diameter 1.5 arcsec from this object in 1 arcsec Gaussian seeing
+FIBERFLUX_R           float32 nanomaggy    Predicted r-band flux within a fiber of diameter 1.5 arcsec from this object in 1 arcsec Gaussian seeing
+FIBERFLUX_Z           float32 nanomaggy    Predicted z-band flux within a fiber of diameter 1.5 arcsec from this object in 1 arcsec Gaussian seeing
+FIBERTOTFLUX_G        float32 nanomaggy    Predicted g-band flux within a fiber of diameter 1.5 arcsec from all sources at this location in 1 arcsec Gaussian seeing
+FIBERTOTFLUX_R        float32 nanomaggy    Predicted r-band flux within a fiber of diameter 1.5 arcsec from all sources at this location in 1 arcsec Gaussian seeing
+FIBERTOTFLUX_Z        float32 nanomaggy    Predicted z-band flux within a fiber of diameter 1.5 arcsec from all sources at this location in 1 arcsec Gaussian seeing
+SERSIC                float32              Power-law index for the Sersic profile model (MORPHTYPE=”SER”)
+SHAPE_R               float32 arcsec       Half-light radius of galaxy model (&gt;0)
+SHAPE_E1              float32              Ellipticity component 1 of galaxy model for galaxy type MORPHTYPE
+SHAPE_E2              float32              Ellipticity component 2 of galaxy model for galaxy type MORPHTYPE
+PHOTSYS               char[1]              &#x27;N&#x27; for the MzLS/BASS photometric system, &#x27;S&#x27; for DECaLS
+PRIORITY_INIT         int64                Target initial priority from target selection bitmasks and OBSCONDITIONS
+NUMOBS_INIT           int64                Initial number of observations for target calculated across target selection bitmasks and OBSCONDITIONS
+SV1_DESI_TARGET [1]_  int64                DESI (dark time program) target selection bitmask for SV1
+SV1_BGS_TARGET [1]_   int64                BGS (bright time program) target selection bitmask for SV1
+SV1_MWS_TARGET [1]_   int64                MWS (bright time program) target selection bitmask for SV1
+SV1_SCND_TARGET [1]_  int64                Secondary target selection bitmask for SV1
+DESI_TARGET           int64                DESI (dark time program) target selection bitmask
+BGS_TARGET            int64                BGS (Bright Galaxy Survey) target selection bitmask
+MWS_TARGET            int64                Milky Way Survey targeting bits
+SCND_TARGET [1]_      int64                Target selection bitmask for secondary programs
+PLATE_RA              float64 deg          Barycentric Right Ascension in ICRS to be used by PlateMaker
+PLATE_DEC             float64 deg          Barycentric Declination in ICRS to be used by PlateMaker
+NUM_ITER              int64                Number of positioner iterations
+FIBER_X               float64 mm           CS5 X location requested by PlateMaker
+FIBER_Y               float64 mm           CS5 Y location requested by PlateMaker
+DELTA_X               float64 mm           CS5 X requested minus actual position
+DELTA_Y               float64 mm           CS5 Y requested minus actual position
+FIBER_RA              float64 deg          RA of actual fiber position
+FIBER_DEC             float64 deg          DEC of actual fiber position
+EXPTIME               float64 s            Length of time shutter was open
+PSF_TO_FIBER_SPECFLUX float64              fraction of light from point-like source captured by 1.5 arcsec diameter fiber given atmospheric seeing
+SV3_MWS_TARGET [1]_   int64                MWS (bright time program) target selection bitmask for SV3
+SV3_SCND_TARGET [1]_  int64                Secondary target selection bitmask for SV3
+SV3_DESI_TARGET [1]_  int64                DESI (dark time program) target selection bitmask for SV3
+SV3_BGS_TARGET [1]_   int64                BGS (bright time program) target selection bitmask for SV3
+SV2_DESI_TARGET [1]_  int64                DESI (dark time program) target selection bitmask for SV2
+SV2_BGS_TARGET [1]_   int64                BGS (bright time program) target selection bitmask for SV2
+SV2_MWS_TARGET [1]_   int64                MWS (bright time program) target selection bitmask for SV2
+SV2_SCND_TARGET [1]_  int64                Secondary target selection bitmask for SV2
+CMX_TARGET [1]_       int64                Target selection bitmask for commissioning
+===================== ======= ============ =========================================================================================================================
 
 .. [1] Optional
 
@@ -1492,72 +1492,80 @@ table for the exposure.
 
 .. rst-class:: columns
 
-========================== ======= ===== ============================================
+========================== ======= ===== ============================================================
 Name                       Type    Units Description
-========================== ======= ===== ============================================
-SUM_RAW_COUNT_Z [1]_       float64       sum counts in wave. range 7600,9800A
-MEDIAN_RAW_COUNT_Z [1]_    float64       median counts/A in wave. range 7600,9800A
-MEDIAN_RAW_SNR_Z [1]_      float64       median SNR/sqrt(A) in wave. range 7600,9800A
-SUM_FFLAT_COUNT_Z [1]_     float64       sum counts in wave. range 7600,9800A
-MEDIAN_FFLAT_COUNT_Z [1]_  float64       median counts/A in wave. range 7600,9800A
-MEDIAN_FFLAT_SNR_Z [1]_    float64       median SNR/sqrt(A) in wave. range 7600,9800A
-SUM_SKYSUB_COUNT_Z [1]_    float64       sum counts in wave. range 7600,9800A
-MEDIAN_SKYSUB_COUNT_Z [1]_ float64       median counts/A in wave. range 7600,9800A
-MEDIAN_SKYSUB_SNR_Z [1]_   float64       median SNR/sqrt(A) in wave. range 7600,9800A
-SUM_CALIB_COUNT_Z [1]_     float64       sum counts in wave. range 7600,9800A
-MEDIAN_CALIB_COUNT_Z [1]_  float64       median counts/A in wave. range 7600,9800A
-MEDIAN_CALIB_SNR_Z [1]_    float64       median SNR/sqrt(A) in wave. range 7600,9800A
-TSNR2_GPBDARK_Z [1]_       float64       from calc_frame_tsnr
-TSNR2_ELG_Z [1]_           float64       from calc_frame_tsnr
-TSNR2_GPBBRIGHT_Z [1]_     float64       from calc_frame_tsnr
-TSNR2_LYA_Z [1]_           float64       from calc_frame_tsnr
-TSNR2_BGS_Z [1]_           float64       from calc_frame_tsnr
+========================== ======= ===== ============================================================
+SUM_RAW_COUNT_Z [1]_       float64       Sum of raw counts in Z camera
+MEDIAN_RAW_COUNT_Z [1]_    float64       Median of raw counts in Z camera
+MEDIAN_RAW_SNR_Z [1]_      float64       Median(raw signal/noise) in Z camera
+SUM_FFLAT_COUNT_Z [1]_     float64       Sum of fiber-flatfielded counts Z camera
+MEDIAN_FFLAT_COUNT_Z [1]_  float64       Median of fiber-flatfielded counts in Z camera
+MEDIAN_FFLAT_SNR_Z [1]_    float64       Median(S/N) of fiberflatfielded counts in Z camera
+SUM_SKYSUB_COUNT_Z [1]_    float64       Sum of sky-subtracted counts in Z camera
+MEDIAN_SKYSUB_COUNT_Z [1]_ float64       Median of sky-subtracted counts in Z camera
+MEDIAN_SKYSUB_SNR_Z [1]_   float64       Median(S/N) of sky-subtracted counts in Z camera
+SUM_CALIB_COUNT_Z [1]_     float64       Sum of calibrated flux in Z camera
+MEDIAN_CALIB_COUNT_Z [1]_  float64       Median of calibrated flux in Z camera
+MEDIAN_CALIB_SNR_Z [1]_    float64       Median(S/N) of calibrated flux in Z camera
+TSNR2_GPBDARK_Z [1]_       float64       template (S/N)^2 for dark targets in guider pass band on Z
+TSNR2_ELG_Z [1]_           float64       ELG Z template (S/N)^2
+TSNR2_GPBBRIGHT_Z [1]_     float64       template (S/N)^2 for bright targets in guider pass band on Z
+TSNR2_LYA_Z [1]_           float64       LYA Z template (S/N)^2
+TSNR2_BGS_Z [1]_           float64       BGS Z template (S/N)^2
 TSNR2_GPBBACKUP_Z [1]_     float64       from calc_frame_tsnr
-TSNR2_QSO_Z [1]_           float64       from calc_frame_tsnr
-TSNR2_LRG_Z [1]_           float64       from calc_frame_tsnr
-TSNR2_LRG_B [1]_           float64       from calc_frame_tsnr
-TSNR2_GPBDARK_B [1]_       float64       from calc_frame_tsnr
-MEDIAN_SKYSUB_SNR_B [1]_   float64       median SNR/sqrt(A) in wave. range 4000,5800A
-MEDIAN_FFLAT_SNR_B [1]_    float64       median SNR/sqrt(A) in wave. range 4000,5800A
-TSNR2_ELG_B [1]_           float64       from calc_frame_tsnr
-TSNR2_BGS_B [1]_           float64       from calc_frame_tsnr
-MEDIAN_CALIB_SNR_B [1]_    float64       median SNR/sqrt(A) in wave. range 4000,5800A
-MEDIAN_FFLAT_COUNT_B [1]_  float64       median counts/A in wave. range 4000,5800A
-TSNR2_QSO_B [1]_           float64       from calc_frame_tsnr
-MEDIAN_SKYSUB_COUNT_B [1]_ float64       median counts/A in wave. range 4000,5800A
-MEDIAN_RAW_COUNT_B [1]_    float64       median counts/A in wave. range 4000,5800A
-TSNR2_GPBBRIGHT_B [1]_     float64       from calc_frame_tsnr
-TSNR2_LYA_B [1]_           float64       from calc_frame_tsnr
-SUM_SKYSUB_COUNT_B [1]_    float64       sum counts in wave. range 4000,5800A
-MEDIAN_CALIB_COUNT_B [1]_  float64       median counts/A in wave. range 4000,5800A
+TSNR2_QSO_Z [1]_           float64       QSO Z template (S/N)^2
+TSNR2_LRG_Z [1]_           float64       LRG Z template (S/N)^2
+TSNR2_LRG_B [1]_           float64       LRG B template (S/N)^2
+TSNR2_GPBDARK_B [1]_       float64       template (S/N)^2 for dark targets in guider pass band on B
+MEDIAN_SKYSUB_SNR_B [1]_   float64       Median(S/N) of sky-subtracted counts in B camera
+MEDIAN_FFLAT_SNR_B [1]_    float64       Median(S/N) of fiberflatfielded counts in B camera
+TSNR2_ELG_B [1]_           float64       ELG B template (S/N)^2
+TSNR2_BGS_B [1]_           float64       BGS B template (S/N)^2
+MEDIAN_CALIB_SNR_B [1]_    float64       Median(S/N) of calibrated flux in B camera
+MEDIAN_FFLAT_COUNT_B [1]_  float64       Median of fiber-flatfielded counts in B camera
+TSNR2_QSO_B [1]_           float64       QSO B template (S/N)^2
+MEDIAN_SKYSUB_COUNT_B [1]_ float64       Median of sky-subtracted counts in B camera
+MEDIAN_RAW_COUNT_B [1]_    float64       Median of raw counts in B camera
+TSNR2_GPBBRIGHT_B [1]_     float64       template (S/N)^2 for bright targets in guider pass band on B
+TSNR2_LYA_B [1]_           float64       LYA B template (S/N)^2
+SUM_SKYSUB_COUNT_B [1]_    float64       Sum of sky-subtracted counts in B camera
+MEDIAN_CALIB_COUNT_B [1]_  float64       Median of calibrated flux in B camera
 TSNR2_GPBBACKUP_B [1]_     float64       from calc_frame_tsnr
-SUM_FFLAT_COUNT_B [1]_     float64       sum counts in wave. range 4000,5800A
-SUM_RAW_COUNT_B [1]_       float64       sum counts in wave. range 4000,5800A
-SUM_CALIB_COUNT_B [1]_     float64       sum counts in wave. range 4000,5800A
-MEDIAN_RAW_SNR_B [1]_      float64       median SNR/sqrt(A) in wave. range 4000,5800A
-SUM_CALIB_COUNT_R [1]_     float64       sum counts in wave. range 5800,7600A
-MEDIAN_RAW_COUNT_R [1]_    float64       median counts/A in wave. range 5800,7600A
-TSNR2_QSO_R [1]_           float64       from calc_frame_tsnr
-TSNR2_LRG_R [1]_           float64       from calc_frame_tsnr
-TSNR2_LYA_R [1]_           float64       from calc_frame_tsnr
-TSNR2_GPBBRIGHT_R [1]_     float64       from calc_frame_tsnr
-SUM_SKYSUB_COUNT_R [1]_    float64       sum counts in wave. range 5800,7600A
-SUM_RAW_COUNT_R [1]_       float64       sum counts in wave. range 5800,7600A
-SUM_FFLAT_COUNT_R [1]_     float64       sum counts in wave. range 5800,7600A
-MEDIAN_FFLAT_SNR_R [1]_    float64       median SNR/sqrt(A) in wave. range 5800,7600A
-TSNR2_BGS_R [1]_           float64       from calc_frame_tsnr
+SUM_FFLAT_COUNT_B [1]_     float64       Sum of fiber-flatfielded counts B camera
+SUM_RAW_COUNT_B [1]_       float64       Sum of raw counts in B camera
+SUM_CALIB_COUNT_B [1]_     float64       Sum of calibrated flux in B camera
+MEDIAN_RAW_SNR_B [1]_      float64       Median(raw signal/noise) in B camera
+SUM_CALIB_COUNT_R [1]_     float64       Sum of calibrated flux in R camera
+MEDIAN_RAW_COUNT_R [1]_    float64       Median of raw counts in R camera
+TSNR2_QSO_R [1]_           float64       QSO R template (S/N)^2
+TSNR2_LRG_R [1]_           float64       LRG R template (S/N)^2
+TSNR2_LYA_R [1]_           float64       LYA R template (S/N)^2
+TSNR2_GPBBRIGHT_R [1]_     float64       template (S/N)^2 for bright targets in guider pass band on R
+SUM_SKYSUB_COUNT_R [1]_    float64       Sum of sky-subtracted counts in R camera
+SUM_RAW_COUNT_R [1]_       float64       Sum of raw counts in R camera
+SUM_FFLAT_COUNT_R [1]_     float64       Sum of fiber-flatfielded counts R camera
+MEDIAN_FFLAT_SNR_R [1]_    float64       Median(S/N) of fiberflatfielded counts in R camera
+TSNR2_BGS_R [1]_           float64       BGS R template (S/N)^2
 TSNR2_GPBBACKUP_R [1]_     float64       from calc_frame_tsnr
-MEDIAN_SKYSUB_SNR_R [1]_   float64       median SNR/sqrt(A) in wave. range 5800,7600A
-MEDIAN_CALIB_SNR_R [1]_    float64       median SNR/sqrt(A) in wave. range 5800,7600A
-MEDIAN_FFLAT_COUNT_R [1]_  float64       median counts/A in wave. range 5800,7600A
-MEDIAN_RAW_SNR_R [1]_      float64       median SNR/sqrt(A) in wave. range 5800,7600A
-MEDIAN_SKYSUB_COUNT_R [1]_ float64       median counts/A in wave. range 5800,7600A
-MEDIAN_CALIB_COUNT_R [1]_  float64       median counts/A in wave. range 5800,7600A
-TSNR2_GPBDARK_R [1]_       float64       from calc_frame_tsnr
-TSNR2_ELG_R [1]_           float64       from calc_frame_tsnr
-========================== ======= ===== ============================================
+MEDIAN_SKYSUB_SNR_R [1]_   float64       Median(S/N) of sky-subtracted counts in R camera
+MEDIAN_CALIB_SNR_R [1]_    float64       Median(S/N) of calibrated flux in R camera
+MEDIAN_FFLAT_COUNT_R [1]_  float64       Median of fiber-flatfielded counts in R camera
+MEDIAN_RAW_SNR_R [1]_      float64       Median(raw signal/noise) in R camera
+MEDIAN_SKYSUB_COUNT_R [1]_ float64       Median of sky-subtracted counts in R camera
+MEDIAN_CALIB_COUNT_R [1]_  float64       Median of calibrated flux in R camera
+TSNR2_GPBDARK_R [1]_       float64       template (S/N)^2 for dark targets in guider pass band on R
+TSNR2_ELG_R [1]_           float64       ELG R template (S/N)^2
+========================== ======= ===== ============================================================
 
 Notes and Examples
 ==================
 
-TODO
+The TSNR2 columns are for "template signal-to-noise squared".
+These measure the signal-to-noise squared weighted by which wavelengths matter
+most for different target types, e.g. QSOs weight blue wavelengths more
+while ELGs weight redder wavelengths more due to the wavelengths of the
+observed emission lines.  For more details, see section 4.14 of
+`Guy et al 2023 <https://ui.adsabs.harvard.edu/abs/2023AJ....165..144G/abstract>`_.
+
+
+

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/frame-CAMERA-EXPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/frame-CAMERA-EXPID.rst
@@ -1366,93 +1366,93 @@ Required Data Table Columns
 
 .. rst-class:: columns
 
-===================== ======= ===== ==============================
-Name                  Type    Units Description
-===================== ======= ===== ==============================
-TARGETID              int64         Unique target ID
-PETAL_LOC             int16         Focal plane petal location 0-9
-DEVICE_LOC            int32         Device location 0-5xx
-LOCATION              int64         1000*PETAL_LOC + DEVICE_LOC
-FIBER                 int32         Fiber number 0-4999
-FIBERSTATUS           int32         Fiber status mask; 0=good
-TARGET_RA             float64
-TARGET_DEC            float64
-PMRA                  float32
-PMDEC                 float32
-REF_EPOCH             float32
-LAMBDA_REF            float32
-FA_TARGET             int64
-FA_TYPE               binary
-OBJTYPE               char[3]
-FIBERASSIGN_X         float32
-FIBERASSIGN_Y         float32
-PRIORITY              int32
-SUBPRIORITY           float64
-OBSCONDITIONS         int32
-RELEASE               int16
-BRICKID               int32
-BRICK_OBJID           int32
-MORPHTYPE             char[4]
-FLUX_G                float32
-FLUX_R                float32
-FLUX_Z                float32
-FLUX_IVAR_G           float32
-FLUX_IVAR_R           float32
-FLUX_IVAR_Z           float32
-MASKBITS              int16
-REF_ID                int64
-REF_CAT               char[2]
-GAIA_PHOT_G_MEAN_MAG  float32
-GAIA_PHOT_BP_MEAN_MAG float32
-GAIA_PHOT_RP_MEAN_MAG float32
-PARALLAX              float32
-BRICKNAME             char[8]
-EBV                   float32
-FLUX_W1               float32
-FLUX_W2               float32
-FLUX_IVAR_W1          float32
-FLUX_IVAR_W2          float32
-FIBERFLUX_G           float32
-FIBERFLUX_R           float32
-FIBERFLUX_Z           float32
-FIBERTOTFLUX_G        float32
-FIBERTOTFLUX_R        float32
-FIBERTOTFLUX_Z        float32
-SERSIC                float32
-SHAPE_R               float32
-SHAPE_E1              float32
-SHAPE_E2              float32
-PHOTSYS               char[1]
-PRIORITY_INIT         int64
-NUMOBS_INIT           int64
-CMX_TARGET [1]_       int64
-DESI_TARGET           int64
-BGS_TARGET            int64
-MWS_TARGET            int64
-SCND_TARGET [1]_      int64
-PLATE_RA              float64
-PLATE_DEC             float64
-NUM_ITER              int64
-FIBER_X               float64
-FIBER_Y               float64
-DELTA_X               float64
-DELTA_Y               float64
-FIBER_RA              float64
-FIBER_DEC             float64
-EXPTIME               float64
-SV1_BGS_TARGET [1]_   int64
-SV1_MWS_TARGET [1]_   int64
-SV1_DESI_TARGET [1]_  int64
-SV1_SCND_TARGET [1]_  int64
-SV3_BGS_TARGET [1]_   int64
-SV3_DESI_TARGET [1]_  int64
-SV3_SCND_TARGET [1]_  int64
-SV3_MWS_TARGET [1]_   int64
-SV2_DESI_TARGET [1]_  int64
-SV2_SCND_TARGET [1]_  int64
-SV2_MWS_TARGET [1]_   int64
-SV2_BGS_TARGET [1]_   int64
-===================== ======= ===== ==============================
+===================== ======= ============ =========================================================================================================================
+Name                  Type    Units        Description
+===================== ======= ============ =========================================================================================================================
+TARGETID              int64                Unique target ID
+PETAL_LOC             int16                Focal plane petal location 0-9
+DEVICE_LOC            int32                Device location 0-5xx
+LOCATION              int64                1000*PETAL_LOC + DEVICE_LOC
+FIBER                 int32                Fiber number 0-4999
+FIBERSTATUS           int32                Fiber status mask; 0=good
+TARGET_RA             float64 deg          Barycentric right ascension in ICRS
+TARGET_DEC            float64 deg          Barycentric declination in ICRS
+PMRA                  float32 mas yr^-1    proper motion in the +RA direction (already including cos(dec))
+PMDEC                 float32 mas yr^-1    Proper motion in the +Dec direction
+REF_EPOCH             float32 yr           Reference epoch for Gaia/Tycho astrometry. Typically 2015.5 for Gaia
+LAMBDA_REF            float32 Angstrom     Requested wavelength at which targets should be centered on fibers
+FA_TARGET             int64                Targeting bit internally used by fiberassign (linked with FA_TYPE)
+FA_TYPE               binary               Fiberassign internal target type (science, standard, sky, safe, suppsky)
+OBJTYPE               char[3]              Object type: TGT, SKY, NON, BAD
+FIBERASSIGN_X         float32 mm           Fiberassign expected CS5 X location on focal plane
+FIBERASSIGN_Y         float32 mm           Fiberassign expected CS5 Y location on focal plane
+PRIORITY              int32                Target current priority
+SUBPRIORITY           float64              Random subpriority [0-1) to break assignment ties
+OBSCONDITIONS         int32                Bitmask of allowed observing conditions
+RELEASE               int16                Imaging surveys release ID
+BRICKID               int32                Brick ID from tractor input
+BRICK_OBJID           int32                Imaging Surveys OBJID on that brick
+MORPHTYPE             char[4]              Imaging Surveys morphological type from Tractor
+FLUX_G                float32 nanomaggy    Flux in the Legacy Survey g-band (AB)
+FLUX_R                float32 nanomaggy    Flux in the Legacy Survey r-band (AB)
+FLUX_Z                float32 nanomaggy    Flux in the Legacy Survey z-band (AB)
+FLUX_IVAR_G           float32 nanomaggy^-2 Inverse variance of FLUX_G (AB)
+FLUX_IVAR_R           float32 nanomaggy^-2 Inverse variance of FLUX_R (AB)
+FLUX_IVAR_Z           float32 nanomaggy^-2 Inverse variance of FLUX_Z (AB)
+MASKBITS              int16                Bitwise mask from the imaging indicating potential issue or blending
+REF_ID                int64                Tyc1*1,000,000+Tyc2*10+Tyc3 for Tycho-2; “sourceid” for Gaia DR2
+REF_CAT               char[2]              Reference catalog source for star: “T2” for Tycho-2, “G2” for Gaia DR2, “L2” for the SGA, empty otherwise
+GAIA_PHOT_G_MEAN_MAG  float32 mag          Gaia G band magnitude
+GAIA_PHOT_BP_MEAN_MAG float32 mag          Gaia BP band magnitude
+GAIA_PHOT_RP_MEAN_MAG float32 mag          Gaia RP band magnitude
+PARALLAX              float32 mas          Reference catalog parallax
+BRICKNAME             char[8]              Brick name from tractor input
+EBV                   float32 mag          Galactic extinction E(B-V) reddening from SFD98
+FLUX_W1               float32 nanomaggy    WISE flux in W1 (AB)
+FLUX_W2               float32 nanomaggy    WISE flux in W2 (AB)
+FLUX_IVAR_W1          float32 nanomaggy^-2 Inverse variance of FLUX_W1 (AB)
+FLUX_IVAR_W2          float32 nanomaggy^-2 Inverse variance of FLUX_W2 (AB)
+FIBERFLUX_G           float32 nanomaggy    Predicted g-band flux within a fiber of diameter 1.5 arcsec from this object in 1 arcsec Gaussian seeing
+FIBERFLUX_R           float32 nanomaggy    Predicted r-band flux within a fiber of diameter 1.5 arcsec from this object in 1 arcsec Gaussian seeing
+FIBERFLUX_Z           float32 nanomaggy    Predicted z-band flux within a fiber of diameter 1.5 arcsec from this object in 1 arcsec Gaussian seeing
+FIBERTOTFLUX_G        float32 nanomaggy    Predicted g-band flux within a fiber of diameter 1.5 arcsec from all sources at this location in 1 arcsec Gaussian seeing
+FIBERTOTFLUX_R        float32 nanomaggy    Predicted r-band flux within a fiber of diameter 1.5 arcsec from all sources at this location in 1 arcsec Gaussian seeing
+FIBERTOTFLUX_Z        float32 nanomaggy    Predicted z-band flux within a fiber of diameter 1.5 arcsec from all sources at this location in 1 arcsec Gaussian seeing
+SERSIC                float32              Power-law index for the Sersic profile model (MORPHTYPE=”SER”)
+SHAPE_R               float32 arcsec       Half-light radius of galaxy model (&gt;0)
+SHAPE_E1              float32              Ellipticity component 1 of galaxy model for galaxy type MORPHTYPE
+SHAPE_E2              float32              Ellipticity component 2 of galaxy model for galaxy type MORPHTYPE
+PHOTSYS               char[1]              &#x27;N&#x27; for the MzLS/BASS photometric system, &#x27;S&#x27; for DECaLS
+PRIORITY_INIT         int64                Target initial priority from target selection bitmasks and OBSCONDITIONS
+NUMOBS_INIT           int64                Initial number of observations for target calculated across target selection bitmasks and OBSCONDITIONS
+CMX_TARGET [1]_       int64                Target selection bitmask for commissioning
+DESI_TARGET           int64                DESI (dark time program) target selection bitmask
+BGS_TARGET            int64                BGS (Bright Galaxy Survey) target selection bitmask
+MWS_TARGET            int64                Milky Way Survey targeting bits
+SCND_TARGET [1]_      int64                Target selection bitmask for secondary programs
+PLATE_RA              float64 deg          Barycentric Right Ascension in ICRS to be used by PlateMaker
+PLATE_DEC             float64 deg          Barycentric Declination in ICRS to be used by PlateMaker
+NUM_ITER              int64                Number of positioner iterations
+FIBER_X               float64 mm           CS5 X location requested by PlateMaker
+FIBER_Y               float64 mm           CS5 Y location requested by PlateMaker
+DELTA_X               float64 mm           CS5 X requested minus actual position
+DELTA_Y               float64 mm           CS5 Y requested minus actual position
+FIBER_RA              float64 deg          RA of actual fiber position
+FIBER_DEC             float64 deg          DEC of actual fiber position
+EXPTIME               float64 s            Length of time shutter was open
+SV1_BGS_TARGET [1]_   int64                BGS (bright time program) target selection bitmask for SV1
+SV1_MWS_TARGET [1]_   int64                MWS (bright time program) target selection bitmask for SV1
+SV1_DESI_TARGET [1]_  int64                DESI (dark time program) target selection bitmask for SV1
+SV1_SCND_TARGET [1]_  int64                Secondary target selection bitmask for SV1
+SV3_BGS_TARGET [1]_   int64                BGS (bright time program) target selection bitmask for SV3
+SV3_DESI_TARGET [1]_  int64                DESI (dark time program) target selection bitmask for SV3
+SV3_SCND_TARGET [1]_  int64                Secondary target selection bitmask for SV3
+SV3_MWS_TARGET [1]_   int64                MWS (bright time program) target selection bitmask for SV3
+SV2_DESI_TARGET [1]_  int64                DESI (dark time program) target selection bitmask for SV2
+SV2_SCND_TARGET [1]_  int64                Secondary target selection bitmask for SV2
+SV2_MWS_TARGET [1]_   int64                MWS (bright time program) target selection bitmask for SV2
+SV2_BGS_TARGET [1]_   int64                BGS (bright time program) target selection bitmask for SV2
+===================== ======= ============ =========================================================================================================================
 
 .. [1] Optional
 

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/sframe-CAMERA-EXPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/sframe-CAMERA-EXPID.rst
@@ -1330,93 +1330,93 @@ Required Data Table Columns
 
 .. rst-class:: columns
 
-===================== ======= ===== ==============================
-Name                  Type    Units Description
-===================== ======= ===== ==============================
-TARGETID              int64         Unique target ID
-PETAL_LOC             int16         Focal plane petal location 0-9
-DEVICE_LOC            int32         Device location 0-5xx
-LOCATION              int64         1000*PETAL_LOC + DEVICE_LOC
-FIBER                 int32         Fiber number 0-4999
-FIBERSTATUS           int32         Fiber status mask; 0=good
-TARGET_RA             float64
-TARGET_DEC            float64
-PMRA                  float32
-PMDEC                 float32
-REF_EPOCH             float32
-LAMBDA_REF            float32
-FA_TARGET             int64
-FA_TYPE               binary
-OBJTYPE               char[3]
-FIBERASSIGN_X         float32
-FIBERASSIGN_Y         float32
-PRIORITY              int32
-SUBPRIORITY           float64
-OBSCONDITIONS         int32
-RELEASE               int16
-BRICKID               int32
-BRICK_OBJID           int32
-MORPHTYPE             char[4]
-FLUX_G                float32
-FLUX_R                float32
-FLUX_Z                float32
-FLUX_IVAR_G           float32
-FLUX_IVAR_R           float32
-FLUX_IVAR_Z           float32
-REF_ID                int64
-REF_CAT               char[2]
-GAIA_PHOT_G_MEAN_MAG  float32
-GAIA_PHOT_BP_MEAN_MAG float32
-GAIA_PHOT_RP_MEAN_MAG float32
-PARALLAX              float32
-BRICKNAME             char[8]
-EBV                   float32
-FLUX_W1               float32
-FLUX_W2               float32
-FLUX_IVAR_W1          float32
-FLUX_IVAR_W2          float32
-FIBERFLUX_G           float32
-FIBERFLUX_R           float32
-FIBERFLUX_Z           float32
-FIBERTOTFLUX_G        float32
-FIBERTOTFLUX_R        float32
-FIBERTOTFLUX_Z        float32
-MASKBITS              int16
-SERSIC                float32
-SHAPE_R               float32
-SHAPE_E1              float32
-SHAPE_E2              float32
-PHOTSYS               char[1]
-PRIORITY_INIT         int64
-NUMOBS_INIT           int64
-SV1_DESI_TARGET [1]_  int64
-SV1_BGS_TARGET [1]_   int64
-SV1_MWS_TARGET [1]_   int64
-SV1_SCND_TARGET [1]_  int64
-DESI_TARGET           int64
-BGS_TARGET            int64
-MWS_TARGET            int64
-PLATE_RA              float64
-PLATE_DEC             float64
-NUM_ITER              int64
-FIBER_X               float64
-FIBER_Y               float64
-DELTA_X               float64
-DELTA_Y               float64
-FIBER_RA              float64
-FIBER_DEC             float64
-EXPTIME               float64
-SCND_TARGET [1]_      int64
-SV3_SCND_TARGET [1]_  int64
-SV3_MWS_TARGET [1]_   int64
-SV3_DESI_TARGET [1]_  int64
-SV3_BGS_TARGET [1]_   int64
-SV2_MWS_TARGET [1]_   int64
-SV2_DESI_TARGET [1]_  int64
-SV2_SCND_TARGET [1]_  int64
-SV2_BGS_TARGET [1]_   int64
-CMX_TARGET [1]_       int64
-===================== ======= ===== ==============================
+===================== ======= ============ =========================================================================================================================
+Name                  Type    Units        Description
+===================== ======= ============ =========================================================================================================================
+TARGETID              int64                Unique target ID
+PETAL_LOC             int16                Focal plane petal location 0-9
+DEVICE_LOC            int32                Device location 0-5xx
+LOCATION              int64                1000*PETAL_LOC + DEVICE_LOC
+FIBER                 int32                Fiber number 0-4999
+FIBERSTATUS           int32                Fiber status mask; 0=good
+TARGET_RA             float64 deg          Barycentric right ascension in ICRS
+TARGET_DEC            float64 deg          Barycentric declination in ICRS
+PMRA                  float32 mas yr^-1    proper motion in the +RA direction (already including cos(dec))
+PMDEC                 float32 mas yr^-1    Proper motion in the +Dec direction
+REF_EPOCH             float32 yr           Reference epoch for Gaia/Tycho astrometry. Typically 2015.5 for Gaia
+LAMBDA_REF            float32 Angstrom     Requested wavelength at which targets should be centered on fibers
+FA_TARGET             int64                Targeting bit internally used by fiberassign (linked with FA_TYPE)
+FA_TYPE               binary               Fiberassign internal target type (science, standard, sky, safe, suppsky)
+OBJTYPE               char[3]              Object type: TGT, SKY, NON, BAD
+FIBERASSIGN_X         float32 mm           Fiberassign expected CS5 X location on focal plane
+FIBERASSIGN_Y         float32 mm           Fiberassign expected CS5 Y location on focal plane
+PRIORITY              int32                Target current priority
+SUBPRIORITY           float64              Random subpriority [0-1) to break assignment ties
+OBSCONDITIONS         int32                Bitmask of allowed observing conditions
+RELEASE               int16                Imaging surveys release ID
+BRICKID               int32                Brick ID from tractor input
+BRICK_OBJID           int32                Imaging Surveys OBJID on that brick
+MORPHTYPE             char[4]              Imaging Surveys morphological type from Tractor
+FLUX_G                float32 nanomaggy    Flux in the Legacy Survey g-band (AB)
+FLUX_R                float32 nanomaggy    Flux in the Legacy Survey r-band (AB)
+FLUX_Z                float32 nanomaggy    Flux in the Legacy Survey z-band (AB)
+FLUX_IVAR_G           float32 nanomaggy^-2 Inverse variance of FLUX_G (AB)
+FLUX_IVAR_R           float32 nanomaggy^-2 Inverse variance of FLUX_R (AB)
+FLUX_IVAR_Z           float32 nanomaggy^-2 Inverse variance of FLUX_Z (AB)
+REF_ID                int64                Tyc1*1,000,000+Tyc2*10+Tyc3 for Tycho-2; “sourceid” for Gaia DR2
+REF_CAT               char[2]              Reference catalog source for star: “T2” for Tycho-2, “G2” for Gaia DR2, “L2” for the SGA, empty otherwise
+GAIA_PHOT_G_MEAN_MAG  float32 mag          Gaia G band magnitude
+GAIA_PHOT_BP_MEAN_MAG float32 mag          Gaia BP band magnitude
+GAIA_PHOT_RP_MEAN_MAG float32 mag          Gaia RP band magnitude
+PARALLAX              float32 mas          Reference catalog parallax
+BRICKNAME             char[8]              Brick name from tractor input
+EBV                   float32 mag          Galactic extinction E(B-V) reddening from SFD98
+FLUX_W1               float32 nanomaggy    WISE flux in W1 (AB)
+FLUX_W2               float32 nanomaggy    WISE flux in W2 (AB)
+FLUX_IVAR_W1          float32 nanomaggy^-2 Inverse variance of FLUX_W1 (AB)
+FLUX_IVAR_W2          float32 nanomaggy^-2 Inverse variance of FLUX_W2 (AB)
+FIBERFLUX_G           float32 nanomaggy    Predicted g-band flux within a fiber of diameter 1.5 arcsec from this object in 1 arcsec Gaussian seeing
+FIBERFLUX_R           float32 nanomaggy    Predicted r-band flux within a fiber of diameter 1.5 arcsec from this object in 1 arcsec Gaussian seeing
+FIBERFLUX_Z           float32 nanomaggy    Predicted z-band flux within a fiber of diameter 1.5 arcsec from this object in 1 arcsec Gaussian seeing
+FIBERTOTFLUX_G        float32 nanomaggy    Predicted g-band flux within a fiber of diameter 1.5 arcsec from all sources at this location in 1 arcsec Gaussian seeing
+FIBERTOTFLUX_R        float32 nanomaggy    Predicted r-band flux within a fiber of diameter 1.5 arcsec from all sources at this location in 1 arcsec Gaussian seeing
+FIBERTOTFLUX_Z        float32 nanomaggy    Predicted z-band flux within a fiber of diameter 1.5 arcsec from all sources at this location in 1 arcsec Gaussian seeing
+MASKBITS              int16                Bitwise mask from the imaging indicating potential issue or blending
+SERSIC                float32              Power-law index for the Sersic profile model (MORPHTYPE=”SER”)
+SHAPE_R               float32 arcsec       Half-light radius of galaxy model (&gt;0)
+SHAPE_E1              float32              Ellipticity component 1 of galaxy model for galaxy type MORPHTYPE
+SHAPE_E2              float32              Ellipticity component 2 of galaxy model for galaxy type MORPHTYPE
+PHOTSYS               char[1]              &#x27;N&#x27; for the MzLS/BASS photometric system, &#x27;S&#x27; for DECaLS
+PRIORITY_INIT         int64                Target initial priority from target selection bitmasks and OBSCONDITIONS
+NUMOBS_INIT           int64                Initial number of observations for target calculated across target selection bitmasks and OBSCONDITIONS
+SV1_DESI_TARGET [1]_  int64                DESI (dark time program) target selection bitmask for SV1
+SV1_BGS_TARGET [1]_   int64                BGS (bright time program) target selection bitmask for SV1
+SV1_MWS_TARGET [1]_   int64                MWS (bright time program) target selection bitmask for SV1
+SV1_SCND_TARGET [1]_  int64                Secondary target selection bitmask for SV1
+DESI_TARGET           int64                DESI (dark time program) target selection bitmask
+BGS_TARGET            int64                BGS (Bright Galaxy Survey) target selection bitmask
+MWS_TARGET            int64                Milky Way Survey targeting bits
+PLATE_RA              float64 deg          Barycentric Right Ascension in ICRS to be used by PlateMaker
+PLATE_DEC             float64 deg          Barycentric Declination in ICRS to be used by PlateMaker
+NUM_ITER              int64                Number of positioner iterations
+FIBER_X               float64 mm           CS5 X location requested by PlateMaker
+FIBER_Y               float64 mm           CS5 Y location requested by PlateMaker
+DELTA_X               float64 mm           CS5 X requested minus actual position
+DELTA_Y               float64 mm           CS5 Y requested minus actual position
+FIBER_RA              float64 deg          RA of actual fiber position
+FIBER_DEC             float64 deg          DEC of actual fiber position
+EXPTIME               float64 s            Length of time shutter was open
+SCND_TARGET [1]_      int64                Target selection bitmask for secondary programs
+SV3_SCND_TARGET [1]_  int64                Secondary target selection bitmask for SV3
+SV3_MWS_TARGET [1]_   int64                MWS (bright time program) target selection bitmask for SV3
+SV3_DESI_TARGET [1]_  int64                DESI (dark time program) target selection bitmask for SV3
+SV3_BGS_TARGET [1]_   int64                BGS (bright time program) target selection bitmask for SV3
+SV2_MWS_TARGET [1]_   int64                MWS (bright time program) target selection bitmask for SV2
+SV2_DESI_TARGET [1]_  int64                DESI (dark time program) target selection bitmask for SV2
+SV2_SCND_TARGET [1]_  int64                Secondary target selection bitmask for SV2
+SV2_BGS_TARGET [1]_   int64                BGS (bright time program) target selection bitmask for SV2
+CMX_TARGET [1]_       int64                Target selection bitmask for commissioning
+===================== ======= ============ =========================================================================================================================
 
 .. [1] Optional
 

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/healpix/SURVEY/PROGRAM/PIXGROUP/PIXNUM/spectra-SURVEY-PROGRAM-PIXNUM.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/healpix/SURVEY/PROGRAM/PIXGROUP/PIXNUM/spectra-SURVEY-PROGRAM-PIXNUM.rst
@@ -4,10 +4,45 @@ spectra-SURVEY-PROGRAM-PIXNUM.fits
 
 :Summary: DESI spectra grouped by nested healpix number
 :Naming Convention: ``spectra-SURVEY-PROGRAM-PIXNUM.fits``, where ``SURVEY`` is
-    *e.g.* ``main`` or ``sv1``, ``PROGRAM`` is *e.g.* ``bright or ``dark``
+    *e.g.* ``main`` or ``sv1``, ``PROGRAM`` is *e.g.* ``bright`` or ``dark``
     and ``PIXNUM`` is the HEALPixel number.
 :Regex: ``spectra-(cmx|main|special|sv1|sv2|sv3)-(backup|bright|dark|other)-[0-9]+\.fits``
 :File Type: FITS, 408 MB
+
+Spectra files contain non-coadded spectra for multiple targets observed on
+multiple individual exposures and cameras.  The format can contain any
+arbitrary set of targets, though the standard DESI spectroscopic pipeline
+outputs are grouped either by a single petal of a given tile,
+or all targets on a single healpix.
+
+Tile-based spectra can be grouped in multiple ways across
+exposures and nights;  see the top-level :doc:`SPECPROD/tiles/ <../../../index>`
+description for an overview of the per-tile GROUPTYPE and GROUPID options.
+Healpix-based spectra are grouped by SURVEY and PROGRAM.
+Science analyses may release spectra in other groups, e.g. all the spectra
+selected for a particular analysis.
+
+See :doc:`coadd files <coadd-SURVEY-PROGRAM-PIXNUM>` for a coadded
+version of the same spectra in a very similar format.
+
+The FIBERMAP table contains metadata about each target, with one row per
+target per exposure.  The corresponding SCORES table contains quantities
+measured from the spectra, also with one row per target per exposure.
+
+The spectra themselves are in a set of image HDUs for the FLUX,
+IVAR (inverse variance), MASK, and spectral RESOLUTION, each prefixed
+with a spectrograph camera name, e.g. B, R, or Z for DESI, though the format
+in general could support other numbers and names of cameras for other
+instruments.  A row of each image HDU correponds to the target from the
+same row index of the FIBERMAP and SCORES HDUs.
+
+See the end of :doc:`tile-based spectra </DESI_SPECTRO_REDUX/SPECPROD/tiles/GROUPTYPE/TILEID/GROUPID/spectra-SPECTROGRAPH-TILEID-GROUPID>`
+for examples of reading this file format.
+
+Note: the table below is the order in which these HDUs appear in DESI spectroscopic
+pipeline output, but the order is arbitrary and they should be read by
+name not by number.
+
 
 Contents
 ========
@@ -54,13 +89,13 @@ Required Header Keywords
     ======== ================ ==== ==============================================
     KEY      Example Value    Type Comment
     ======== ================ ==== ==============================================
-    SPGRP    healpixel        str
-    SPGRPVAL 26371            int
-    HPXPIXEL 26371            int
-    HPXNSIDE 64               int
-    HPXNEST  True             str
-    SURVEY   main             str
-    PROGRAM  bright           str
+    SPGRP    healpix          str  Spectral grouping method
+    SPGRPVAL 26371            int  Grouping value = healpixel number
+    HPXPIXEL 26371            int  Nested nside=64 healpixel number
+    HPXNSIDE 64               int  Healpix nside
+    HPXNEST  True             str  Healpix nested? (vs. ring)
+    SURVEY   main             str  DESI Survey (sv1, sv3, main...)
+    PROGRAM  bright           str  DESI Program (dark, bright, ...)
     CHECKSUM 8DPU9BMR8BMR8BMR str  HDU checksum updated 2021-07-19T17:59:29
     DATASUM  0                str  data unit checksum updated 2021-07-19T17:59:29
     ======== ================ ==== ==============================================
@@ -72,7 +107,7 @@ HDU01
 
 EXTNAME = FIBERMAP
 
-fibermap table with two additional columns NIGHT and EXPID.
+Fibermap table with per-target metdata.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -84,100 +119,102 @@ Required Header Keywords
     ======== ================ ==== ==============================================
     KEY      Example Value    Type Comment
     ======== ================ ==== ==============================================
-    NAXIS1   413              int  length of dimension 1
-    NAXIS2   1031             int  length of dimension 2
-    CHECKSUM U9Fia89iV8Cia89i str  HDU checksum updated 2021-07-19T17:59:29
-    DATASUM  3589169610       str  data unit checksum updated 2021-07-19T17:59:29
+    NAXIS1   413              int  Width of table in bytes
+    NAXIS2   1031             int  Number of rows in table
+    CHECKSUM U9Fia89iV8Cia89i str  HDU checksum
+    DATASUM  3589169610       str  data unit checksum
     ======== ================ ==== ==============================================
 
 Required Data Table Columns
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+Propagated from the FIBERMAP HDU of the input :doc:`cframe files </DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/cframe-CAMERA-EXPID>`.
+
 .. rst-class:: columns
 
-===================== ======= ===== ===========
-Name                  Type    Units Description
-===================== ======= ===== ===========
-TARGETID              int64
-PETAL_LOC             int16
-DEVICE_LOC            int32
-LOCATION              int64
-FIBER                 int32
-FIBERSTATUS           int32
-TARGET_RA             float64
-TARGET_DEC            float64
-PMRA                  float32
-PMDEC                 float32
-REF_EPOCH             float32
-LAMBDA_REF            float32
-FA_TARGET             int64
-FA_TYPE               binary
-OBJTYPE               char[3]
-FIBERASSIGN_X         float32
-FIBERASSIGN_Y         float32
-PRIORITY              int32
-SUBPRIORITY           float64
-OBSCONDITIONS         int32
-RELEASE               int16
-BRICKID               int32
-BRICK_OBJID           int32
-MORPHTYPE             char[4]
-FLUX_G                float32
-FLUX_R                float32
-FLUX_Z                float32
-FLUX_IVAR_G           float32
-FLUX_IVAR_R           float32
-FLUX_IVAR_Z           float32
-MASKBITS              int16
-REF_ID                int64
-REF_CAT               char[2]
-GAIA_PHOT_G_MEAN_MAG  float32
-GAIA_PHOT_BP_MEAN_MAG float32
-GAIA_PHOT_RP_MEAN_MAG float32
-PARALLAX              float32
-BRICKNAME             char[8]
-EBV                   float32
-FLUX_W1               float32
-FLUX_W2               float32
-FLUX_IVAR_W1          float32
-FLUX_IVAR_W2          float32
-FIBERFLUX_G           float32
-FIBERFLUX_R           float32
-FIBERFLUX_Z           float32
-FIBERTOTFLUX_G        float32
-FIBERTOTFLUX_R        float32
-FIBERTOTFLUX_Z        float32
-SERSIC                float32
-SHAPE_R               float32
-SHAPE_E1              float32
-SHAPE_E2              float32
-PHOTSYS               char[1]
-PRIORITY_INIT         int64
-NUMOBS_INIT           int64
-SV1_DESI_TARGET [1]_  int64
-SV1_BGS_TARGET [1]_   int64
-SV1_MWS_TARGET [1]_   int64
-SV1_SCND_TARGET [1]_  int64
-DESI_TARGET           int64
-BGS_TARGET            int64
-MWS_TARGET            int64
-SCND_TARGET           int64
-PLATE_RA              float64
-PLATE_DEC             float64
-NUM_ITER              int64
-FIBER_X               float64
-FIBER_Y               float64
-DELTA_X               float64
-DELTA_Y               float64
-FIBER_RA              float64
-FIBER_DEC             float64
-EXPTIME               float64
-PSF_TO_FIBER_SPECFLUX float64
+===================== ======= ============ =========================================================================================================================
+Name                  Type    Units        Description
+===================== ======= ============ =========================================================================================================================
+TARGETID              int64                Unique DESI target ID
+PETAL_LOC             int16                Petal location [0-9]
+DEVICE_LOC            int32                Device location on focal plane [0-523]
+LOCATION              int64                Location on the focal plane PETAL_LOC*1000 + DEVICE_LOC
+FIBER                 int32                Fiber ID on the CCDs [0-4999]
+FIBERSTATUS           int32                Fiber status mask. 0=good
+TARGET_RA             float64 deg          Barycentric right ascension in ICRS
+TARGET_DEC            float64 deg          Barycentric declination in ICRS
+PMRA                  float32 mas yr^-1    proper motion in the +RA direction (already including cos(dec))
+PMDEC                 float32 mas yr^-1    Proper motion in the +Dec direction
+REF_EPOCH             float32 yr           Reference epoch for Gaia/Tycho astrometry. Typically 2015.5 for Gaia
+LAMBDA_REF            float32 Angstrom     Requested wavelength at which targets should be centered on fibers
+FA_TARGET             int64                Targeting bit internally used by fiberassign (linked with FA_TYPE)
+FA_TYPE               binary               Fiberassign internal target type (science, standard, sky, safe, suppsky)
+OBJTYPE               char[3]              Object type: TGT, SKY, NON, BAD
+FIBERASSIGN_X         float32 mm           Fiberassign expected CS5 X location on focal plane
+FIBERASSIGN_Y         float32 mm           Fiberassign expected CS5 Y location on focal plane
+PRIORITY              int32                Target current priority
+SUBPRIORITY           float64              Random subpriority [0-1) to break assignment ties
+OBSCONDITIONS         int32                Bitmask of allowed observing conditions
+RELEASE               int16                Imaging surveys release ID
+BRICKID               int32                Brick ID from tractor input
+BRICK_OBJID           int32                Imaging Surveys OBJID on that brick
+MORPHTYPE             char[4]              Imaging Surveys morphological type from Tractor
+FLUX_G                float32 nanomaggy    Flux in the Legacy Survey g-band (AB)
+FLUX_R                float32 nanomaggy    Flux in the Legacy Survey r-band (AB)
+FLUX_Z                float32 nanomaggy    Flux in the Legacy Survey z-band (AB)
+FLUX_IVAR_G           float32 nanomaggy^-2 Inverse variance of FLUX_G (AB)
+FLUX_IVAR_R           float32 nanomaggy^-2 Inverse variance of FLUX_R (AB)
+FLUX_IVAR_Z           float32 nanomaggy^-2 Inverse variance of FLUX_Z (AB)
+MASKBITS              int16                Bitwise mask from the imaging indicating potential issue or blending
+REF_ID                int64                Tyc1*1,000,000+Tyc2*10+Tyc3 for Tycho-2; “sourceid” for Gaia DR2
+REF_CAT               char[2]              Reference catalog source for star: “T2” for Tycho-2, “G2” for Gaia DR2, “L2” for the SGA, empty otherwise
+GAIA_PHOT_G_MEAN_MAG  float32 mag          Gaia G band magnitude
+GAIA_PHOT_BP_MEAN_MAG float32 mag          Gaia BP band magnitude
+GAIA_PHOT_RP_MEAN_MAG float32 mag          Gaia RP band magnitude
+PARALLAX              float32 mas          Reference catalog parallax
+BRICKNAME             char[8]              Brick name from tractor input
+EBV                   float32 mag          Galactic extinction E(B-V) reddening from SFD98
+FLUX_W1               float32 nanomaggy    WISE flux in W1 (AB)
+FLUX_W2               float32 nanomaggy    WISE flux in W2 (AB)
+FLUX_IVAR_W1          float32 nanomaggy^-2 Inverse variance of FLUX_W1 (AB)
+FLUX_IVAR_W2          float32 nanomaggy^-2 Inverse variance of FLUX_W2 (AB)
+FIBERFLUX_G           float32 nanomaggy    Predicted g-band flux within a fiber of diameter 1.5 arcsec from this object in 1 arcsec Gaussian seeing
+FIBERFLUX_R           float32 nanomaggy    Predicted r-band flux within a fiber of diameter 1.5 arcsec from this object in 1 arcsec Gaussian seeing
+FIBERFLUX_Z           float32 nanomaggy    Predicted z-band flux within a fiber of diameter 1.5 arcsec from this object in 1 arcsec Gaussian seeing
+FIBERTOTFLUX_G        float32 nanomaggy    Predicted g-band flux within a fiber of diameter 1.5 arcsec from all sources at this location in 1 arcsec Gaussian seeing
+FIBERTOTFLUX_R        float32 nanomaggy    Predicted r-band flux within a fiber of diameter 1.5 arcsec from all sources at this location in 1 arcsec Gaussian seeing
+FIBERTOTFLUX_Z        float32 nanomaggy    Predicted z-band flux within a fiber of diameter 1.5 arcsec from all sources at this location in 1 arcsec Gaussian seeing
+SERSIC                float32              Power-law index for the Sersic profile model (MORPHTYPE=”SER”)
+SHAPE_R               float32 arcsec       Half-light radius of galaxy model (&gt;0)
+SHAPE_E1              float32              Ellipticity component 1 of galaxy model for galaxy type MORPHTYPE
+SHAPE_E2              float32              Ellipticity component 2 of galaxy model for galaxy type MORPHTYPE
+PHOTSYS               char[1]              &#x27;N&#x27; for the MzLS/BASS photometric system, &#x27;S&#x27; for DECaLS
+PRIORITY_INIT         int64                Target initial priority from target selection bitmasks and OBSCONDITIONS
+NUMOBS_INIT           int64                Initial number of observations for target calculated across target selection bitmasks and OBSCONDITIONS
+SV1_DESI_TARGET [1]_  int64                DESI (dark time program) target selection bitmask for SV1
+SV1_BGS_TARGET [1]_   int64                BGS (bright time program) target selection bitmask for SV1
+SV1_MWS_TARGET [1]_   int64                MWS (bright time program) target selection bitmask for SV1
+SV1_SCND_TARGET [1]_  int64                Secondary target selection bitmask for SV1
+DESI_TARGET           int64                DESI (dark time program) target selection bitmask
+BGS_TARGET            int64                BGS (Bright Galaxy Survey) target selection bitmask
+MWS_TARGET            int64                Milky Way Survey targeting bits
+SCND_TARGET           int64                Target selection bitmask for secondary programs
+PLATE_RA              float64 deg          Barycentric Right Ascension in ICRS to be used by PlateMaker
+PLATE_DEC             float64 deg          Barycentric Declination in ICRS to be used by PlateMaker
+NUM_ITER              int64                Number of positioner iterations
+FIBER_X               float64 mm           CS5 X location requested by PlateMaker
+FIBER_Y               float64 mm           CS5 Y location requested by PlateMaker
+DELTA_X               float64 mm           CS5 X requested minus actual position
+DELTA_Y               float64 mm           CS5 Y requested minus actual position
+FIBER_RA              float64 deg          RA of actual fiber position
+FIBER_DEC             float64 deg          DEC of actual fiber position
+EXPTIME               float64 s            Length of time shutter was open
+PSF_TO_FIBER_SPECFLUX float64              fraction of light from point-like source captured by 1.5 arcsec diameter fiber given atmospheric seeing
 NIGHT                 int32
-EXPID                 int32
-MJD                   float64
-TILEID                int32
-===================== ======= ===== ===========
+EXPID                 int32                DESI Exposure ID number
+MJD                   float64              Modified Julian Date when shutter was opened for this exposure
+TILEID                int32                Unique DESI tile ID
+===================== ======= ============ =========================================================================================================================
 
 .. [1] Optional
 
@@ -186,7 +223,9 @@ HDU02
 
 EXTNAME = SCORES
 
-*Summarize the contents of this HDU.*
+Scores / metrics measured from the spectra for use in QA and systematics studies.
+These are propagated from the input
+:doc:`cframe SCORES HDU </DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/cframe-CAMERA-EXPID>`.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -207,78 +246,79 @@ Required Data Table Columns
 
 .. rst-class:: columns
 
-===================== ======= ===== ===================
+===================== ======= ===== ============================================================
 Name                  Type    Units Description
-===================== ======= ===== ===================
-TARGETID              int64         label for field   1
-SUM_RAW_COUNT_B       float64       label for field   2
-MEDIAN_RAW_COUNT_B    float64       label for field   3
-MEDIAN_RAW_SNR_B      float64       label for field   4
-SUM_FFLAT_COUNT_B     float64       label for field   5
-MEDIAN_FFLAT_COUNT_B  float64       label for field   6
-MEDIAN_FFLAT_SNR_B    float64       label for field   7
-SUM_SKYSUB_COUNT_B    float64       label for field   8
-MEDIAN_SKYSUB_COUNT_B float64       label for field   9
-MEDIAN_SKYSUB_SNR_B   float64       label for field  10
-SUM_CALIB_COUNT_B     float64       label for field  11
-MEDIAN_CALIB_COUNT_B  float64       label for field  12
-MEDIAN_CALIB_SNR_B    float64       label for field  13
-TSNR2_GPBDARK_B       float64       label for field  14
-TSNR2_ELG_B           float64       label for field  15
-TSNR2_GPBBRIGHT_B     float64       label for field  16
-TSNR2_LYA_B           float64       label for field  17
-TSNR2_BGS_B           float64       label for field  18
-TSNR2_GPBBACKUP_B     float64       label for field  19
-TSNR2_QSO_B           float64       label for field  20
-TSNR2_LRG_B           float64       label for field  21
-SUM_RAW_COUNT_R       float64       label for field  22
-MEDIAN_RAW_COUNT_R    float64       label for field  23
-MEDIAN_RAW_SNR_R      float64       label for field  24
-SUM_FFLAT_COUNT_R     float64       label for field  25
-MEDIAN_FFLAT_COUNT_R  float64       label for field  26
-MEDIAN_FFLAT_SNR_R    float64       label for field  27
-SUM_SKYSUB_COUNT_R    float64       label for field  28
-MEDIAN_SKYSUB_COUNT_R float64       label for field  29
-MEDIAN_SKYSUB_SNR_R   float64       label for field  30
-SUM_CALIB_COUNT_R     float64       label for field  31
-MEDIAN_CALIB_COUNT_R  float64       label for field  32
-MEDIAN_CALIB_SNR_R    float64       label for field  33
-TSNR2_GPBDARK_R       float64       label for field  34
-TSNR2_ELG_R           float64       label for field  35
-TSNR2_GPBBRIGHT_R     float64       label for field  36
-TSNR2_LYA_R           float64       label for field  37
-TSNR2_BGS_R           float64       label for field  38
-TSNR2_GPBBACKUP_R     float64       label for field  39
-TSNR2_QSO_R           float64       label for field  40
-TSNR2_LRG_R           float64       label for field  41
-SUM_RAW_COUNT_Z       float64       label for field  42
-MEDIAN_RAW_COUNT_Z    float64       label for field  43
-MEDIAN_RAW_SNR_Z      float64       label for field  44
-SUM_FFLAT_COUNT_Z     float64       label for field  45
-MEDIAN_FFLAT_COUNT_Z  float64       label for field  46
-MEDIAN_FFLAT_SNR_Z    float64       label for field  47
-SUM_SKYSUB_COUNT_Z    float64       label for field  48
-MEDIAN_SKYSUB_COUNT_Z float64       label for field  49
-MEDIAN_SKYSUB_SNR_Z   float64       label for field  50
-SUM_CALIB_COUNT_Z     float64       label for field  51
-MEDIAN_CALIB_COUNT_Z  float64       label for field  52
-MEDIAN_CALIB_SNR_Z    float64       label for field  53
-TSNR2_GPBDARK_Z       float64       label for field  54
-TSNR2_ELG_Z           float64       label for field  55
-TSNR2_GPBBRIGHT_Z     float64       label for field  56
-TSNR2_LYA_Z           float64       label for field  57
-TSNR2_BGS_Z           float64       label for field  58
-TSNR2_GPBBACKUP_Z     float64       label for field  59
-TSNR2_QSO_Z           float64       label for field  60
-TSNR2_LRG_Z           float64       label for field  61
-===================== ======= ===== ===================
+===================== ======= ===== ============================================================
+TARGETID              int64         Unique DESI target ID
+SUM_RAW_COUNT_B       float64       Sum of raw counts in B camera
+MEDIAN_RAW_COUNT_B    float64       Median of raw counts in B camera
+MEDIAN_RAW_SNR_B      float64       Median(raw signal/noise) in B camera
+SUM_FFLAT_COUNT_B     float64       Sum of fiber-flatfielded counts B camera
+MEDIAN_FFLAT_COUNT_B  float64       Median of fiber-flatfielded counts in B camera
+MEDIAN_FFLAT_SNR_B    float64       Median(S/N) of fiberflatfielded counts in B camera
+SUM_SKYSUB_COUNT_B    float64       Sum of sky-subtracted counts in B camera
+MEDIAN_SKYSUB_COUNT_B float64       Median of sky-subtracted counts in B camera
+MEDIAN_SKYSUB_SNR_B   float64       Median(S/N) of sky-subtracted counts in B camera
+SUM_CALIB_COUNT_B     float64       Sum of calibrated flux in B camera
+MEDIAN_CALIB_COUNT_B  float64       Median of calibrated flux in B camera
+MEDIAN_CALIB_SNR_B    float64       Median(S/N) of calibrated flux in B camera
+TSNR2_GPBDARK_B       float64       template (S/N)^2 for dark targets in guider pass band on B
+TSNR2_ELG_B           float64       ELG B template (S/N)^2
+TSNR2_GPBBRIGHT_B     float64       template (S/N)^2 for bright targets in guider pass band on B
+TSNR2_LYA_B           float64       LYA B template (S/N)^2
+TSNR2_BGS_B           float64       BGS B template (S/N)^2
+TSNR2_GPBBACKUP_B     float64
+TSNR2_QSO_B           float64       QSO B template (S/N)^2
+TSNR2_LRG_B           float64       LRG B template (S/N)^2
+SUM_RAW_COUNT_R       float64       Sum of raw counts in R camera
+MEDIAN_RAW_COUNT_R    float64       Median of raw counts in R camera
+MEDIAN_RAW_SNR_R      float64       Median(raw signal/noise) in R camera
+SUM_FFLAT_COUNT_R     float64       Sum of fiber-flatfielded counts R camera
+MEDIAN_FFLAT_COUNT_R  float64       Median of fiber-flatfielded counts in R camera
+MEDIAN_FFLAT_SNR_R    float64       Median(S/N) of fiberflatfielded counts in R camera
+SUM_SKYSUB_COUNT_R    float64       Sum of sky-subtracted counts in R camera
+MEDIAN_SKYSUB_COUNT_R float64       Median of sky-subtracted counts in R camera
+MEDIAN_SKYSUB_SNR_R   float64       Median(S/N) of sky-subtracted counts in R camera
+SUM_CALIB_COUNT_R     float64       Sum of calibrated flux in R camera
+MEDIAN_CALIB_COUNT_R  float64       Median of calibrated flux in R camera
+MEDIAN_CALIB_SNR_R    float64       Median(S/N) of calibrated flux in R camera
+TSNR2_GPBDARK_R       float64       template (S/N)^2 for dark targets in guider pass band on R
+TSNR2_ELG_R           float64       ELG R template (S/N)^2
+TSNR2_GPBBRIGHT_R     float64       template (S/N)^2 for bright targets in guider pass band on R
+TSNR2_LYA_R           float64       LYA R template (S/N)^2
+TSNR2_BGS_R           float64       BGS R template (S/N)^2
+TSNR2_GPBBACKUP_R     float64
+TSNR2_QSO_R           float64       QSO R template (S/N)^2
+TSNR2_LRG_R           float64       LRG R template (S/N)^2
+SUM_RAW_COUNT_Z       float64       Sum of raw counts in Z camera
+MEDIAN_RAW_COUNT_Z    float64       Median of raw counts in Z camera
+MEDIAN_RAW_SNR_Z      float64       Median(raw signal/noise) in Z camera
+SUM_FFLAT_COUNT_Z     float64       Sum of fiber-flatfielded counts Z camera
+MEDIAN_FFLAT_COUNT_Z  float64       Median of fiber-flatfielded counts in Z camera
+MEDIAN_FFLAT_SNR_Z    float64       Median(S/N) of fiberflatfielded counts in Z camera
+SUM_SKYSUB_COUNT_Z    float64       Sum of sky-subtracted counts in Z camera
+MEDIAN_SKYSUB_COUNT_Z float64       Median of sky-subtracted counts in Z camera
+MEDIAN_SKYSUB_SNR_Z   float64       Median(S/N) of sky-subtracted counts in Z camera
+SUM_CALIB_COUNT_Z     float64       Sum of calibrated flux in Z camera
+MEDIAN_CALIB_COUNT_Z  float64       Median of calibrated flux in Z camera
+MEDIAN_CALIB_SNR_Z    float64       Median(S/N) of calibrated flux in Z camera
+TSNR2_GPBDARK_Z       float64       template (S/N)^2 for dark targets in guider pass band on Z
+TSNR2_ELG_Z           float64       ELG Z template (S/N)^2
+TSNR2_GPBBRIGHT_Z     float64       template (S/N)^2 for bright targets in guider pass band on Z
+TSNR2_LYA_Z           float64       LYA Z template (S/N)^2
+TSNR2_BGS_Z           float64       BGS Z template (S/N)^2
+TSNR2_GPBBACKUP_Z     float64
+TSNR2_QSO_Z           float64       QSO Z template (S/N)^2
+TSNR2_LRG_Z           float64       LRG Z template (S/N)^2
+===================== ======= ===== ============================================================
 
 HDU03
 -----
 
 EXTNAME = B_WAVELENGTH
 
-Wavelength[nwave] array in Angstroms of b-channel spectra
+1D array of B-camera wavelengths in Angstrom, in vacuum (not in air),
+in the rest frame of the solar system barycenter.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -290,7 +330,7 @@ Required Header Keywords
     ====== ============= ==== =====================
     KEY    Example Value Type Comment
     ====== ============= ==== =====================
-    NAXIS1 2751          int  length of data axis 1
+    NAXIS1 2751          int  Number of wavelengths
     BUNIT  Angstrom      str
     ====== ============= ==== =====================
 
@@ -301,7 +341,11 @@ HDU04
 
 EXTNAME = B_FLUX
 
-Flux[nspec,nwave] array in 1e-17 erg/(s cm2 Angstrom) of b-channel spectra
+2D array of calibrated spectral flux of dimension ``[nspec, nwave]``
+in units of 1e-17 erg / (s cm2 Angstrom).
+``nspec`` is the number of fibers per camera.
+``nwave`` in the length of the wavelength array.
+The spectra of all fibers share the same wavelength grid, given in HDU B_WAVELENGTH.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -313,8 +357,8 @@ Required Header Keywords
     ====== ============================ ==== =====================
     KEY    Example Value                Type Comment
     ====== ============================ ==== =====================
-    NAXIS1 2751                         int  length of data axis 1
-    NAXIS2 1031                         int  length of data axis 2
+    NAXIS1 2751                         int  ``nwave`` number of wavelengths
+    NAXIS2 1031                         int  ``nspec`` number of spectra
     BUNIT  10**-17 erg/(s cm2 Angstrom) str
     ====== ============================ ==== =====================
 
@@ -325,7 +369,11 @@ HDU05
 
 EXTNAME = B_IVAR
 
-Inverse variance of b-channel flux array
+Inverse variance of flux (1/sigma^2) in units of (10^{-17} erg/s/cm2/A)^-2.
+Uncertainties comprise statistical uncertainties from the error propagation
+of the initial CCD pixel variance, the calibration uncertainties,
+plus an additional term on bright sky lines to account for the
+imperfect sky subtraction.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -337,8 +385,8 @@ Required Header Keywords
     ====== ================================= ==== =====================
     KEY    Example Value                     Type Comment
     ====== ================================= ==== =====================
-    NAXIS1 2751                              int  length of data axis 1
-    NAXIS2 1031                              int  length of data axis 2
+    NAXIS1 2751                              int  ``nwave`` number of wavelengths
+    NAXIS2 1031                              int  ``nspec`` number of spectra
     BUNIT  10**+34 (s2 cm4 Angstrom2) / erg2 str
     ====== ================================= ==== =====================
 
@@ -349,7 +397,8 @@ HDU06
 
 EXTNAME = B_MASK
 
-Mask[nspec,nwave] of b-channel flux array.
+Mask of spectral data; 0=good.
+See the :doc:`bitmask documentation </bitmasks>` page for the definition of the bits.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -361,8 +410,8 @@ Required Header Keywords
     ====== ============= ==== ==========================================
     KEY    Example Value Type Comment
     ====== ============= ==== ==========================================
-    NAXIS1 8             int  width of table in bytes
-    NAXIS2 1031          int  number of rows in table
+    NAXIS1 2751          int  ``nwave`` number of wavelengths
+    NAXIS2 1031          int  ``nspec`` number of spectra
     BZERO  2147483648    int  offset data range to that of unsigned long
     BSCALE 1             int  default scaling factor
     ====== ============= ==== ==========================================
@@ -374,7 +423,10 @@ HDU07
 
 EXTNAME = B_RESOLUTION
 
-Diagonals of b-channel resolution matrix
+Resolution matrix stored as a 3D sparse matrix, modeling the
+per-fiber non-Gaussian effective line-spread-function resolution.
+See the :doc:`frame RESOLUTION HDU </DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/frame-CAMERA-EXPID>`
+documentation for details about using this HDU.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -386,9 +438,9 @@ Required Header Keywords
     ====== ============= ==== =====================
     KEY    Example Value Type Comment
     ====== ============= ==== =====================
-    NAXIS1 2751          int  length of data axis 1
-    NAXIS2 11            int  length of data axis 2
-    NAXIS3 1031          int  length of data axis 3
+    NAXIS1 2751          int  ``nwave`` number of wavelengths
+    NAXIS2 11            int  ``ndiag`` number of diagonals
+    NAXIS3 1031          int  ``nspec`` number of spectra
     ====== ============= ==== =====================
 
 Data: FITS image [float32, 2751x11x1031]
@@ -411,7 +463,8 @@ HDU08
 
 EXTNAME = R_WAVELENGTH
 
-Wavelength[nwave] array in Angstroms of r-channel spectra
+1D array of R-camera wavelengths in Angstrom, in vacuum (not in air),
+in the rest frame of the solar system barycenter.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -423,7 +476,7 @@ Required Header Keywords
     ====== ============= ==== =====================
     KEY    Example Value Type Comment
     ====== ============= ==== =====================
-    NAXIS1 2326          int  length of data axis 1
+    NAXIS1 2326          int  number of wavelengths
     BUNIT  Angstrom      str
     ====== ============= ==== =====================
 
@@ -434,7 +487,11 @@ HDU09
 
 EXTNAME = R_FLUX
 
-Flux[nspec,nwave] array in 1e-17 erg/(s cm2 Angstrom) of r-channel spectra
+2D array of calibrated spectral flux of dimension ``[nspec, nwave]``
+in units of 1e-17 erg / (s cm2 Angstrom).
+``nspec`` is the number of fibers per camera.
+``nwave`` in the length of the wavelength array.
+The spectra of all fibers share the same wavelength grid, given in HDU R_WAVELENGTH.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -446,8 +503,8 @@ Required Header Keywords
     ====== ============================ ==== =====================
     KEY    Example Value                Type Comment
     ====== ============================ ==== =====================
-    NAXIS1 2326                         int  length of data axis 1
-    NAXIS2 1031                         int  length of data axis 2
+    NAXIS1 2326                         int  ``nwave`` number of wavelengths
+    NAXIS2 1031                         int  ``nspec`` number of spectra
     BUNIT  10**-17 erg/(s cm2 Angstrom) str
     ====== ============================ ==== =====================
 
@@ -458,7 +515,11 @@ HDU10
 
 EXTNAME = R_IVAR
 
-Inverse variance of r-channel flux array
+Inverse variance of flux (1/sigma^2) in units of (10^{-17} erg/s/cm2/A)^-2.
+Uncertainties comprise statistical uncertainties from the error propagation
+of the initial CCD pixel variance, the calibration uncertainties,
+plus an additional term on bright sky lines to account for the
+imperfect sky subtraction.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -470,8 +531,8 @@ Required Header Keywords
     ====== ================================= ==== =====================
     KEY    Example Value                     Type Comment
     ====== ================================= ==== =====================
-    NAXIS1 2326                              int  length of data axis 1
-    NAXIS2 1031                              int  length of data axis 2
+    NAXIS1 2326                              int  ``nwave`` number of wavelengths
+    NAXIS2 1031                              int  ``nspec`` number of spectra
     BUNIT  10**+34 (s2 cm4 Angstrom2) / erg2 str
     ====== ================================= ==== =====================
 
@@ -482,7 +543,8 @@ HDU11
 
 EXTNAME = R_MASK
 
-Mask[nspec,nwave] of r-channel flux array.
+Mask of spectral data; 0=good.
+See the :doc:`bitmask documentation </bitmasks>` page for the definition of the bits.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -494,8 +556,8 @@ Required Header Keywords
     ====== ============= ==== ==========================================
     KEY    Example Value Type Comment
     ====== ============= ==== ==========================================
-    NAXIS1 8             int  width of table in bytes
-    NAXIS2 1031          int  number of rows in table
+    NAXIS1 2326          int  ``nwave`` number of wavelengths
+    NAXIS2 1031          int  ``nspec`` number of spectra
     BZERO  2147483648    int  offset data range to that of unsigned long
     BSCALE 1             int  default scaling factor
     ====== ============= ==== ==========================================
@@ -507,9 +569,10 @@ HDU12
 
 EXTNAME = R_RESOLUTION
 
-Diagonals of r-channel resolution matrix.
-
-See B_RESOLUTION HDU for description of the format.
+Resolution matrix stored as a 3D sparse matrix, modeling the
+per-fiber non-Gaussian effective line-spread-function resolution.
+See the :doc:`frame RESOLUTION HDU </DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/frame-CAMERA-EXPID>`
+documentation for details about using this HDU.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -533,7 +596,8 @@ HDU13
 
 EXTNAME = Z_WAVELENGTH
 
-Wavelength[nwave] array in Angstroms of z-channel spectra
+1D array of Z-camera wavelengths in Angstrom, in vacuum (not in air),
+in the rest frame of the solar system barycenter.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -545,7 +609,7 @@ Required Header Keywords
     ====== ============= ==== =====================
     KEY    Example Value Type Comment
     ====== ============= ==== =====================
-    NAXIS1 2881          int  length of data axis 1
+    NAXIS1 2881          int  ``nwave`` number of wavelengths
     BUNIT  Angstrom      str
     ====== ============= ==== =====================
 
@@ -556,7 +620,11 @@ HDU14
 
 EXTNAME = Z_FLUX
 
-Flux[nspec,nwave] array in 1e-17 erg/(s cm2 Angstrom) of z-channel spectra
+2D array of calibrated spectral flux of dimension ``[nspec, nwave]``
+in units of 1e-17 erg / (s cm2 Angstrom).
+``nspec`` is the number of fibers per camera.
+``nwave`` in the length of the wavelength array.
+The spectra of all fibers share the same wavelength grid, given in HDU Z_WAVELENGTH.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -568,8 +636,8 @@ Required Header Keywords
     ====== ============================ ==== =====================
     KEY    Example Value                Type Comment
     ====== ============================ ==== =====================
-    NAXIS1 2881                         int  length of data axis 1
-    NAXIS2 1031                         int  length of data axis 2
+    NAXIS1 2881                         int  ``nwave`` number of wavelengths
+    NAXIS2 1031                         int  ``nspec`` number of spectra
     BUNIT  10**-17 erg/(s cm2 Angstrom) str
     ====== ============================ ==== =====================
 
@@ -580,7 +648,11 @@ HDU15
 
 EXTNAME = Z_IVAR
 
-Inverse variance of z-channel flux array
+Inverse variance of flux (1/sigma^2) in units of (10^{-17} erg/s/cm2/A)^-2.
+Uncertainties comprise statistical uncertainties from the error propagation
+of the initial CCD pixel variance, the calibration uncertainties,
+plus an additional term on bright sky lines to account for the
+imperfect sky subtraction.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -592,8 +664,8 @@ Required Header Keywords
     ====== ================================= ==== =====================
     KEY    Example Value                     Type Comment
     ====== ================================= ==== =====================
-    NAXIS1 2881                              int  length of data axis 1
-    NAXIS2 1031                              int  length of data axis 2
+    NAXIS1 2881                              int  ``nwave`` number of wavelengths
+    NAXIS2 1031                              int  ``nspec`` number of spectra
     BUNIT  10**+34 (s2 cm4 Angstrom2) / erg2 str
     ====== ================================= ==== =====================
 
@@ -604,7 +676,8 @@ HDU16
 
 EXTNAME = Z_MASK
 
-Mask[nspec,nwave] of z-channel flux array.
+Mask of spectral data; 0=good.
+See the :doc:`bitmask documentation </bitmasks>` page for the definition of the bits.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -616,8 +689,8 @@ Required Header Keywords
     ====== ============= ==== ==========================================
     KEY    Example Value Type Comment
     ====== ============= ==== ==========================================
-    NAXIS1 8             int  width of table in bytes
-    NAXIS2 1031          int  number of rows in table
+    NAXIS1 2881          int  ``nwave`` number of wavelengths
+    NAXIS2 1031          int  ``nspec`` number of spectra
     BZERO  2147483648    int  offset data range to that of unsigned long
     BSCALE 1             int  default scaling factor
     ====== ============= ==== ==========================================
@@ -631,7 +704,10 @@ EXTNAME = Z_RESOLUTION
 
 Diagonals of z-channel resolution matrix.
 
-See B_RESOLUTION HDU for description of the format.
+Resolution matrix stored as a 3D sparse matrix, modeling the
+per-fiber non-Gaussian effective line-spread-function resolution.
+See the :doc:`frame RESOLUTION HDU </DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/frame-CAMERA-EXPID>`
+documentation for details about using this HDU.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -643,9 +719,9 @@ Required Header Keywords
     ====== ============= ==== =====================
     KEY    Example Value Type Comment
     ====== ============= ==== =====================
-    NAXIS1 2881          int  length of data axis 1
-    NAXIS2 11            int  length of data axis 2
-    NAXIS3 1031          int  length of data axis 3
+    NAXIS1 2881          int  ``nwave`` number of wavelengths
+    NAXIS2 11            int  ``ndiag`` number of diagonals
+    NAXIS3 1031          int  ``nspec`` number of spectra
     ====== ============= ==== =====================
 
 Data: FITS image [float32, 2881x11x1031]
@@ -658,10 +734,4 @@ The format supports arbitrary channel names as long as for each channel {X}
 there is a set of HDUs named {X}_WAVELENGTH, {X}_FLUX, {X}_IVAR, {X}_MASK,
 {X}_RESOLUTION.
 
-Upcoming changes
-================
 
-The following changes are not yet in the spectra files, but will be added in
-the future:
-
-* signal-to-noise per band

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/preproc/NIGHT/EXPID/fibermap-EXPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/preproc/NIGHT/EXPID/fibermap-EXPID.rst
@@ -16,7 +16,7 @@ Contents
 Number EXTNAME  Type     Contents
 ====== ======== ======== ===================
 HDU0_           IMAGE    Keywords only
-HDU1_  FIBERMAP BINTABLE *Brief Description*
+HDU1_  FIBERMAP BINTABLE Target metadata including photometry and fiber assignments
 ====== ======== ======== ===================
 
 
@@ -25,8 +25,6 @@ FITS Header Units
 
 HDU0
 ----
-
-*Summarize the contents of this HDU.*
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -49,7 +47,7 @@ HDU1
 
 EXTNAME = FIBERMAP
 
-*Summarize the contents of this HDU.*
+Target metadata including photometry, fiber assignments, and as-observed positions.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -518,93 +516,93 @@ Required Data Table Columns
 
 .. rst-class:: columns
 
-===================== ======= ===== ===========
-Name                  Type    Units Description
-===================== ======= ===== ===========
-TARGETID              int64
-PETAL_LOC             int16
-DEVICE_LOC            int32
-LOCATION              int64
-FIBER                 int32
-FIBERSTATUS           int32
-TARGET_RA             float64
-TARGET_DEC            float64
-PMRA                  float32
-PMDEC                 float32
-REF_EPOCH             float32
-LAMBDA_REF            float32
-FA_TARGET             int64
-FA_TYPE               binary
-OBJTYPE               char[3]
-FIBERASSIGN_X         float32
-FIBERASSIGN_Y         float32
-PRIORITY              int32
-SUBPRIORITY           float64
-OBSCONDITIONS         int32
-RELEASE               int16
-BRICKNAME             char[8]
-BRICKID               int32
-BRICK_OBJID           int32
-MORPHTYPE             char[4]
-EBV                   float32
-FLUX_G                float32
-FLUX_R                float32
-FLUX_Z                float32
-FLUX_W1               float32
-FLUX_W2               float32
-FLUX_IVAR_G           float32
-FLUX_IVAR_R           float32
-FLUX_IVAR_Z           float32
-FLUX_IVAR_W1          float32
-FLUX_IVAR_W2          float32
-FIBERFLUX_G           float32
-FIBERFLUX_R           float32
-FIBERFLUX_Z           float32
-FIBERTOTFLUX_G        float32
-FIBERTOTFLUX_R        float32
-FIBERTOTFLUX_Z        float32
-MASKBITS              int16
-SERSIC                float32
-SHAPE_R               float32
-SHAPE_E1              float32
-SHAPE_E2              float32
-REF_ID                int64
-REF_CAT               char[2]
-GAIA_PHOT_G_MEAN_MAG  float32
-GAIA_PHOT_BP_MEAN_MAG float32
-GAIA_PHOT_RP_MEAN_MAG float32
-PARALLAX              float32
-PHOTSYS               char[1]
-PRIORITY_INIT         int64
-NUMOBS_INIT           int64
-SV1_DESI_TARGET [1]_  int64
-SV1_BGS_TARGET [1]_   int64
-SV1_MWS_TARGET [1]_   int64
-SV1_SCND_TARGET [1]_  int64
-DESI_TARGET           int64
-BGS_TARGET            int64
-MWS_TARGET            int64
-SCND_TARGET [1]_      int64
-PLATE_RA              float64
-PLATE_DEC             float64
-NUM_ITER              int64
-FIBER_X               float64
-FIBER_Y               float64
-DELTA_X               float64
-DELTA_Y               float64
-FIBER_RA              float64
-FIBER_DEC             float64
-EXPTIME               float64
-SV3_DESI_TARGET [1]_  int64
-SV3_BGS_TARGET [1]_   int64
-SV3_SCND_TARGET [1]_  int64
-SV3_MWS_TARGET [1]_   int64
-SV2_DESI_TARGET [1]_  int64
-SV2_MWS_TARGET [1]_   int64
-SV2_SCND_TARGET [1]_  int64
-SV2_BGS_TARGET [1]_   int64
-CMX_TARGET [1]_       int64
-===================== ======= ===== ===========
+===================== ======= ============ =========================================================================================================================
+Name                  Type    Units        Description
+===================== ======= ============ =========================================================================================================================
+TARGETID              int64                Unique DESI target ID
+PETAL_LOC             int16                Petal location [0-9]
+DEVICE_LOC            int32                Device location on focal plane [0-523]
+LOCATION              int64                Location on the focal plane PETAL_LOC*1000 + DEVICE_LOC
+FIBER                 int32                Fiber ID on the CCDs [0-4999]
+FIBERSTATUS           int32                Fiber status mask. 0=good
+TARGET_RA             float64 deg          Barycentric right ascension in ICRS
+TARGET_DEC            float64 deg          Barycentric declination in ICRS
+PMRA                  float32 mas yr^-1    proper motion in the +RA direction (already including cos(dec))
+PMDEC                 float32 mas yr^-1    Proper motion in the +Dec direction
+REF_EPOCH             float32 yr           Reference epoch for Gaia/Tycho astrometry. Typically 2015.5 for Gaia
+LAMBDA_REF            float32 Angstrom     Requested wavelength at which targets should be centered on fibers
+FA_TARGET             int64                Targeting bit internally used by fiberassign (linked with FA_TYPE)
+FA_TYPE               binary               Fiberassign internal target type (science, standard, sky, safe, suppsky)
+OBJTYPE               char[3]              Object type: TGT, SKY, NON, BAD
+FIBERASSIGN_X         float32 mm           Fiberassign expected CS5 X location on focal plane
+FIBERASSIGN_Y         float32 mm           Fiberassign expected CS5 Y location on focal plane
+PRIORITY              int32                Target current priority
+SUBPRIORITY           float64              Random subpriority [0-1) to break assignment ties
+OBSCONDITIONS         int32                Bitmask of allowed observing conditions
+RELEASE               int16                Imaging surveys release ID
+BRICKNAME             char[8]              Brick name from tractor input
+BRICKID               int32                Brick ID from tractor input
+BRICK_OBJID           int32                Imaging Surveys OBJID on that brick
+MORPHTYPE             char[4]              Imaging Surveys morphological type from Tractor
+EBV                   float32 mag          Galactic extinction E(B-V) reddening from SFD98
+FLUX_G                float32 nanomaggy    Flux in the Legacy Survey g-band (AB)
+FLUX_R                float32 nanomaggy    Flux in the Legacy Survey r-band (AB)
+FLUX_Z                float32 nanomaggy    Flux in the Legacy Survey z-band (AB)
+FLUX_W1               float32 nanomaggy    WISE flux in W1 (AB)
+FLUX_W2               float32 nanomaggy    WISE flux in W2 (AB)
+FLUX_IVAR_G           float32 nanomaggy^-2 Inverse variance of FLUX_G (AB)
+FLUX_IVAR_R           float32 nanomaggy^-2 Inverse variance of FLUX_R (AB)
+FLUX_IVAR_Z           float32 nanomaggy^-2 Inverse variance of FLUX_Z (AB)
+FLUX_IVAR_W1          float32 nanomaggy^-2 Inverse variance of FLUX_W1 (AB)
+FLUX_IVAR_W2          float32 nanomaggy^-2 Inverse variance of FLUX_W2 (AB)
+FIBERFLUX_G           float32 nanomaggy    Predicted g-band flux within a fiber of diameter 1.5 arcsec from this object in 1 arcsec Gaussian seeing
+FIBERFLUX_R           float32 nanomaggy    Predicted r-band flux within a fiber of diameter 1.5 arcsec from this object in 1 arcsec Gaussian seeing
+FIBERFLUX_Z           float32 nanomaggy    Predicted z-band flux within a fiber of diameter 1.5 arcsec from this object in 1 arcsec Gaussian seeing
+FIBERTOTFLUX_G        float32 nanomaggy    Predicted g-band flux within a fiber of diameter 1.5 arcsec from all sources at this location in 1 arcsec Gaussian seeing
+FIBERTOTFLUX_R        float32 nanomaggy    Predicted r-band flux within a fiber of diameter 1.5 arcsec from all sources at this location in 1 arcsec Gaussian seeing
+FIBERTOTFLUX_Z        float32 nanomaggy    Predicted z-band flux within a fiber of diameter 1.5 arcsec from all sources at this location in 1 arcsec Gaussian seeing
+MASKBITS              int16                Bitwise mask from the imaging indicating potential issue or blending
+SERSIC                float32              Power-law index for the Sersic profile model (MORPHTYPE=”SER”)
+SHAPE_R               float32 arcsec       Half-light radius of galaxy model (&gt;0)
+SHAPE_E1              float32              Ellipticity component 1 of galaxy model for galaxy type MORPHTYPE
+SHAPE_E2              float32              Ellipticity component 2 of galaxy model for galaxy type MORPHTYPE
+REF_ID                int64                Tyc1*1,000,000+Tyc2*10+Tyc3 for Tycho-2; “sourceid” for Gaia DR2
+REF_CAT               char[2]              Reference catalog source for star: “T2” for Tycho-2, “G2” for Gaia DR2, “L2” for the SGA, empty otherwise
+GAIA_PHOT_G_MEAN_MAG  float32 mag          Gaia G band magnitude
+GAIA_PHOT_BP_MEAN_MAG float32 mag          Gaia BP band magnitude
+GAIA_PHOT_RP_MEAN_MAG float32 mag          Gaia RP band magnitude
+PARALLAX              float32 mas          Reference catalog parallax
+PHOTSYS               char[1]              &#x27;N&#x27; for the MzLS/BASS photometric system, &#x27;S&#x27; for DECaLS
+PRIORITY_INIT         int64                Target initial priority from target selection bitmasks and OBSCONDITIONS
+NUMOBS_INIT           int64                Initial number of observations for target calculated across target selection bitmasks and OBSCONDITIONS
+SV1_DESI_TARGET [1]_  int64                DESI (dark time program) target selection bitmask for SV1
+SV1_BGS_TARGET [1]_   int64                BGS (bright time program) target selection bitmask for SV1
+SV1_MWS_TARGET [1]_   int64                MWS (bright time program) target selection bitmask for SV1
+SV1_SCND_TARGET [1]_  int64                Secondary target selection bitmask for SV1
+DESI_TARGET           int64                DESI (dark time program) target selection bitmask
+BGS_TARGET            int64                BGS (Bright Galaxy Survey) target selection bitmask
+MWS_TARGET            int64                Milky Way Survey targeting bits
+SCND_TARGET [1]_      int64                Target selection bitmask for secondary programs
+PLATE_RA              float64 deg          Barycentric Right Ascension in ICRS to be used by PlateMaker
+PLATE_DEC             float64 deg          Barycentric Declination in ICRS to be used by PlateMaker
+NUM_ITER              int64                Number of positioner iterations
+FIBER_X               float64 mm           CS5 X location requested by PlateMaker
+FIBER_Y               float64 mm           CS5 Y location requested by PlateMaker
+DELTA_X               float64 mm           CS5 X requested minus actual position
+DELTA_Y               float64 mm           CS5 Y requested minus actual position
+FIBER_RA              float64 deg          RA of actual fiber position
+FIBER_DEC             float64 deg          DEC of actual fiber position
+EXPTIME               float64 s            Length of time shutter was open
+SV3_DESI_TARGET [1]_  int64                DESI (dark time program) target selection bitmask for SV3
+SV3_BGS_TARGET [1]_   int64                BGS (bright time program) target selection bitmask for SV3
+SV3_SCND_TARGET [1]_  int64                Secondary target selection bitmask for SV3
+SV3_MWS_TARGET [1]_   int64                MWS (bright time program) target selection bitmask for SV3
+SV2_DESI_TARGET [1]_  int64                DESI (dark time program) target selection bitmask for SV2
+SV2_MWS_TARGET [1]_   int64                MWS (bright time program) target selection bitmask for SV2
+SV2_SCND_TARGET [1]_  int64                Secondary target selection bitmask for SV2
+SV2_BGS_TARGET [1]_   int64                BGS (bright time program) target selection bitmask for SV2
+CMX_TARGET [1]_       int64                Target selection bitmask for commissioning
+===================== ======= ============ =========================================================================================================================
 
 .. [1] Optional
 

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/tiles/GROUPTYPE/TILEID/GROUPID/coadd-SPECTROGRAPH-TILEID-GROUPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/tiles/GROUPTYPE/TILEID/GROUPID/coadd-SPECTROGRAPH-TILEID-GROUPID.rst
@@ -122,8 +122,6 @@ Required Header Keywords
 Required Data Table Columns
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-TODO: add units
-
 .. rst-class:: columns
 
 ========================== ======= ============ ===============================================================================================================================
@@ -135,8 +133,8 @@ DEVICE_LOC                 int32                Device location on focal plane [
 LOCATION                   int64                Location on the focal plane PETAL_LOC*1000 + DEVICE_LOC
 FIBER                      int32                Fiber ID on the CCDs [0-4999]
 COADD_FIBERSTATUS          int32                bitwise-AND of input FIBERSTATUS
-TARGET_RA                  float64 deg          Target right ascension
-TARGET_DEC                 float64 deg          Target declination
+TARGET_RA                  float64 deg          Barycentric right ascension in ICRS
+TARGET_DEC                 float64 deg          Barycentric declination in ICRS
 PMRA                       float32 mas yr^-1    proper motion in the +RA direction (already including cos(dec))
 PMDEC                      float32 mas yr^-1    Proper motion in the +Dec direction
 REF_EPOCH                  float32 yr           Reference epoch for Gaia/Tycho astrometry. Typically 2015.5 for Gaia
@@ -197,8 +195,8 @@ DESI_TARGET                int64                DESI (dark time program) target 
 BGS_TARGET                 int64                BGS (Bright Galaxy Survey) target selection bitmask
 MWS_TARGET                 int64                Milky Way Survey targeting bits
 SCND_TARGET [1]_           int64                Target selection bitmask for secondary programs
-PLATE_RA                   float64 deg          Right Ascension to be used by PlateMaker
-PLATE_DEC                  float64 deg          Declination to be used by PlateMaker
+PLATE_RA                   float64 deg          Barycentric Right Ascension in ICRS to be used by PlateMaker
+PLATE_DEC                  float64 deg          Barycentric Declination in ICRS to be used by PlateMaker
 TILEID                     int32                Unique DESI tile ID
 COADD_NUMEXP               int16                Number of exposures in coadd
 COADD_EXPTIME              float32 s            Summed exposure time for coadd
@@ -270,8 +268,8 @@ FIBERSTATUS           int32            Fiber status mask. 0=good
 FIBERASSIGN_X         float32 mm       Fiberassign expected CS5 X location on focal plane
 FIBERASSIGN_Y         float32 mm       Fiberassign expected CS5 Y location on focal plane
 LAMBDA_REF            float32 Angstrom Requested wavelength at which targets should be centered on fibers
-PLATE_RA              float64 deg      Right Ascension to be used by PlateMaker
-PLATE_DEC             float64 deg      Declination to be used by PlateMaker
+PLATE_RA              float64 deg      Barycentric Right Ascension in ICRS to be used by PlateMaker
+PLATE_DEC             float64 deg      Barycentric Declination in ICRS to be used by PlateMaker
 NUM_ITER              int64            Number of positioner iterations
 FIBER_X               float64 mm       CS5 X location requested by PlateMaker
 FIBER_Y               float64 mm       CS5 Y location requested by PlateMaker
@@ -395,7 +393,7 @@ EXTNAME = B_RESOLUTION
 
 Resolution matrix stored as diagonals of a 3D sparse matrix.
 See the frame file :ref:`RESOLUTION documentation <frame-hdu4-resolution>`
-for how thease are interpreted and used.
+for how these are interpreted and used.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -415,6 +413,19 @@ Required Header Keywords
     ======== ================ ==== ==============================================
 
 Data: FITS image [float32, 2751x11x500]
+
+A sparse resolution matrix may be created for spectrum ``i`` with::
+
+    from desispec.resolution import Resolution
+    R = Resolution(data[i])
+
+Or using lower-level scipy.sparse matrices::
+
+    import scipy.sparse
+    import numpy as np
+    nspec, ndiag, nwave = data.shape
+    offsets = ndiag//2 - np.arange(ndiag, dtype=int)
+    R = scipy.sparse.dia_matrix((data[i], offsets), shape=(nwave, nwave))
 
 HDU08
 -----
@@ -692,7 +703,7 @@ EXTNAME = SCORES
 Scores / metrics measured from the spectra for use in QA and systematics studies.
 These are coadded from the input
 :doc:`cframe SCORES HDU </DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/cframe-CAMERA-EXPID>`
-files;  see that page for details.
+files.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -704,7 +715,7 @@ Required Header Keywords
     ======== ================ ==== ==============================================
     KEY      Example Value    Type Comment
     ======== ================ ==== ==============================================
-    NAXIS1   172              int
+    NAXIS1   172              int  Width of table in bytes
     NAXIS2   500              int  Number of spectra
     ENCODING ascii            str
     CHECKSUM EpXcGmWcEmWcEmWc str  HDU checksum updated 2021-07-16T14:01:59
@@ -716,9 +727,9 @@ Required Data Table Columns
 
 .. rst-class:: columns
 
-=================== ======= ===== ============================================
+=================== ======= ===== ============================================================
 Name                Type    Units Description
-=================== ======= ===== ============================================
+=================== ======= ===== ============================================================
 TARGETID            int64         Unique DESI target ID
 INTEG_COADD_FLUX_B  float32       integ. flux in wave. range 4000,5800A
 MEDIAN_COADD_FLUX_B float32       median flux in wave. range 4000,5800A
@@ -729,39 +740,39 @@ MEDIAN_COADD_SNR_R  float32       median SNR/sqrt(A) in wave. range 5800,7600A
 INTEG_COADD_FLUX_Z  float32       integ. flux in wave. range 7600,9800A
 MEDIAN_COADD_FLUX_Z float32       median flux in wave. range 7600,9800A
 MEDIAN_COADD_SNR_Z  float32       median SNR/sqrt(A) in wave. range 7600,9800A
-TSNR2_GPBDARK_B     float32       GPBDARK B template (S/N)^2
+TSNR2_GPBDARK_B     float32       template (S/N)^2 for dark targets in guider pass band on B
 TSNR2_ELG_B         float32       ELG B template (S/N)^2
-TSNR2_GPBBRIGHT_B   float32       GPBBRIGHT B template (S/N)^2
+TSNR2_GPBBRIGHT_B   float32       template (S/N)^2 for bright targets in guider pass band on B
 TSNR2_LYA_B         float32       LYA B template (S/N)^2
 TSNR2_BGS_B         float32       BGS B template (S/N)^2
 TSNR2_GPBBACKUP_B   float32       GPBBACKUP B template (S/N)^2
 TSNR2_QSO_B         float32       QSO B template (S/N)^2
 TSNR2_LRG_B         float32       LRG B template (S/N)^2
-TSNR2_GPBDARK_R     float32       GPBDARK R template (S/N)^2
+TSNR2_GPBDARK_R     float32       template (S/N)^2 for dark targets in guider pass band on R
 TSNR2_ELG_R         float32       ELG R template (S/N)^2
-TSNR2_GPBBRIGHT_R   float32       GPBBRIGHT R template (S/N)^2
+TSNR2_GPBBRIGHT_R   float32       template (S/N)^2 for bright targets in guider pass band on R
 TSNR2_LYA_R         float32       LYA R template (S/N)^2
 TSNR2_BGS_R         float32       BGS R template (S/N)^2
 TSNR2_GPBBACKUP_R   float32       GPBBACKUP R template (S/N)^2
 TSNR2_QSO_R         float32       QSO R template (S/N)^2
 TSNR2_LRG_R         float32       LRG R template (S/N)^2
-TSNR2_GPBDARK_Z     float32       GPBDARK Z template (S/N)^2
+TSNR2_GPBDARK_Z     float32       template (S/N)^2 for dark targets in guider pass band on Z
 TSNR2_ELG_Z         float32       ELG Z template (S/N)^2
-TSNR2_GPBBRIGHT_Z   float32       GPBBRIGHT Z template (S/N)^2
+TSNR2_GPBBRIGHT_Z   float32       template (S/N)^2 for bright targets in guider pass band on Z
 TSNR2_LYA_Z         float32       LYA Z template (S/N)^2
 TSNR2_BGS_Z         float32       BGS Z template (S/N)^2
 TSNR2_GPBBACKUP_Z   float32       GPBBACKUP Z template (S/N)^2
 TSNR2_QSO_Z         float32       QSO Z template (S/N)^2
 TSNR2_LRG_Z         float32       LRG Z template (S/N)^2
-TSNR2_GPBDARK       float32       GPBDARK template (S/N)^2 summed over B,R,Z
+TSNR2_GPBDARK       float32       template (S/N)^2 for dark targets in guider pass band
 TSNR2_ELG           float32       ELG template (S/N)^2 summed over B,R,Z
-TSNR2_GPBBRIGHT     float32       GPBBRIGHT template (S/N)^2 summed over B,R,Z
+TSNR2_GPBBRIGHT     float32       template (S/N)^2 for bright targets in guider pass band
 TSNR2_LYA           float32       LYA template (S/N)^2 summed over B,R,Z
 TSNR2_BGS           float32       BGS template (S/N)^2 summed over B,R,Z
 TSNR2_GPBBACKUP     float32       GPBBACKUP template (S/N)^2 summed over B,R,Z
 TSNR2_QSO           float32       QSO template (S/N)^2 summed over B,R,Z
 TSNR2_LRG           float32       LRG template (S/N)^2 summed over B,R,Z
-=================== ======= ===== ============================================
+=================== ======= ===== ============================================================
 
 
 Notes and Examples

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/tiles/GROUPTYPE/TILEID/GROUPID/spectra-SPECTROGRAPH-TILEID-GROUPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/tiles/GROUPTYPE/TILEID/GROUPID/spectra-SPECTROGRAPH-TILEID-GROUPID.rst
@@ -41,7 +41,7 @@ same row index of the FIBERMAP and SCORES HDUs.
 Details are given below, with examples for reading and interpreting the
 spectra files at the end.
 
-Note: the above is the order in which these HDUs appear in DESI spectroscopic
+Note: the table below is the order in which these HDUs appear in DESI spectroscopic
 pipeline output, but the order is arbitrary and they should be read by
 name not by number.
 
@@ -133,15 +133,14 @@ Required Header Keywords
     ======== ================ ==== ==============================================
     NAXIS1   413              int  Width of table in bytes
     NAXIS2   500              int  Number of unique targets (table rows)
-    CHECKSUM TcPqUbPoTbPoTbPo str  HDU checksum updated 2021-07-15T00:33:13
-    DATASUM  1051947488       str  data unit checksum updated 2021-07-15T00:33:13
+    CHECKSUM TcPqUbPoTbPoTbPo str  HDU checksum
+    DATASUM  1051947488       str  data unit checksum
     ======== ================ ==== ==============================================
 
 Required Data Table Columns
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-See the :doc:`fibermap documentation </DESI_SPECTRO_REDUX/SPECPROD/preproc/NIGHT/EXPID/fibermap-EXPID>` page
-for detailed descriptions of the columns.
+Propagated from the FIBERMAP HDU of the input :doc:`cframe files </DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/cframe-CAMERA-EXPID>`.
 
 .. rst-class:: columns
 
@@ -152,10 +151,10 @@ TARGETID              int64                Unique DESI target ID
 PETAL_LOC             int16                Petal location [0-9]
 DEVICE_LOC            int32                Device location on focal plane [0-523]
 LOCATION              int64                Location on the focal plane PETAL_LOC*1000 + DEVICE_LOC
-FIBER                 int32
+FIBER                 int32                Fiber ID on the CCDs [0-4999]
 FIBERSTATUS           int32                Fiber status mask. 0=good
-TARGET_RA             float64 deg          Target right ascension
-TARGET_DEC            float64 deg          Target declination
+TARGET_RA             float64 deg          Barycentric right ascension in ICRS
+TARGET_DEC            float64 deg          Barycentric declination in ICRS
 PMRA                  float32 mas yr^-1    proper motion in the +RA direction (already including cos(dec))
 PMDEC                 float32 mas yr^-1    Proper motion in the +Dec direction
 REF_EPOCH             float32 yr           Reference epoch for Gaia/Tycho astrometry. Typically 2015.5 for Gaia
@@ -216,8 +215,8 @@ DESI_TARGET           int64                DESI (dark time program) target selec
 BGS_TARGET            int64                BGS (Bright Galaxy Survey) target selection bitmask
 MWS_TARGET            int64                Milky Way Survey targeting bits
 SCND_TARGET [1]_      int64                Target selection bitmask for secondary programs
-PLATE_RA              float64 deg          Right Ascension to be used by PlateMaker
-PLATE_DEC             float64 deg          Declination to be used by PlateMaker
+PLATE_RA              float64 deg          Barycentric Right Ascension in ICRS to be used by PlateMaker
+PLATE_DEC             float64 deg          Barycentric Declination in ICRS to be used by PlateMaker
 NUM_ITER              int64                Number of positioner iterations
 FIBER_X               float64 mm           CS5 X location requested by PlateMaker
 FIBER_Y               float64 mm           CS5 Y location requested by PlateMaker
@@ -242,8 +241,7 @@ EXTNAME = SCORES
 
 Scores / metrics measured from the spectra for use in QA and systematics studies.
 These are propagated from the input
-:doc:`cframe SCORES HDU </DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/cframe-CAMERA-EXPID>`;
-see that page for details.
+:doc:`cframe SCORES HDU </DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/cframe-CAMERA-EXPID>`.
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -267,71 +265,71 @@ documentation for details about the columns.
 
 .. rst-class:: columns
 
-===================== ======= ===== ======================
+===================== ======= ===== ============================================================
 Name                  Type    Units Description
-===================== ======= ===== ======================
+===================== ======= ===== ============================================================
 TARGETID              int64         Unique DESI target ID
-SUM_RAW_COUNT_B       float64
-MEDIAN_RAW_COUNT_B    float64
-MEDIAN_RAW_SNR_B      float64
-SUM_FFLAT_COUNT_B     float64
-MEDIAN_FFLAT_COUNT_B  float64
-MEDIAN_FFLAT_SNR_B    float64
-SUM_SKYSUB_COUNT_B    float64
-MEDIAN_SKYSUB_COUNT_B float64
-MEDIAN_SKYSUB_SNR_B   float64
-SUM_CALIB_COUNT_B     float64
-MEDIAN_CALIB_COUNT_B  float64
-MEDIAN_CALIB_SNR_B    float64
-TSNR2_GPBDARK_B       float64
+SUM_RAW_COUNT_B       float64       Sum of raw counts in B camera
+MEDIAN_RAW_COUNT_B    float64       Median of raw counts in B camera
+MEDIAN_RAW_SNR_B      float64       Median(raw signal/noise) in B camera
+SUM_FFLAT_COUNT_B     float64       Sum of fiber-flatfielded counts B camera
+MEDIAN_FFLAT_COUNT_B  float64       Median of fiber-flatfielded counts in B camera
+MEDIAN_FFLAT_SNR_B    float64       Median(S/N) of fiberflatfielded counts in B camera
+SUM_SKYSUB_COUNT_B    float64       Sum of sky-subtracted counts in B camera
+MEDIAN_SKYSUB_COUNT_B float64       Median of sky-subtracted counts in B camera
+MEDIAN_SKYSUB_SNR_B   float64       Median(S/N) of sky-subtracted counts in B camera
+SUM_CALIB_COUNT_B     float64       Sum of calibrated flux in B camera
+MEDIAN_CALIB_COUNT_B  float64       Median of calibrated flux in B camera
+MEDIAN_CALIB_SNR_B    float64       Median(S/N) of calibrated flux in B camera
+TSNR2_GPBDARK_B       float64       template (S/N)^2 for dark targets in guider pass band on B
 TSNR2_ELG_B           float64       ELG B template (S/N)^2
-TSNR2_GPBBRIGHT_B     float64
+TSNR2_GPBBRIGHT_B     float64       template (S/N)^2 for bright targets in guider pass band on B
 TSNR2_LYA_B           float64       LYA B template (S/N)^2
 TSNR2_BGS_B           float64       BGS B template (S/N)^2
 TSNR2_GPBBACKUP_B     float64
 TSNR2_QSO_B           float64       QSO B template (S/N)^2
 TSNR2_LRG_B           float64       LRG B template (S/N)^2
-SUM_RAW_COUNT_R       float64
-MEDIAN_RAW_COUNT_R    float64
-MEDIAN_RAW_SNR_R      float64
-SUM_FFLAT_COUNT_R     float64
-MEDIAN_FFLAT_COUNT_R  float64
-MEDIAN_FFLAT_SNR_R    float64
-SUM_SKYSUB_COUNT_R    float64
-MEDIAN_SKYSUB_COUNT_R float64
-MEDIAN_SKYSUB_SNR_R   float64
-SUM_CALIB_COUNT_R     float64
-MEDIAN_CALIB_COUNT_R  float64
-MEDIAN_CALIB_SNR_R    float64
-TSNR2_GPBDARK_R       float64
+SUM_RAW_COUNT_R       float64       Sum of raw counts in R camera
+MEDIAN_RAW_COUNT_R    float64       Median of raw counts in R camera
+MEDIAN_RAW_SNR_R      float64       Median(raw signal/noise) in R camera
+SUM_FFLAT_COUNT_R     float64       Sum of fiber-flatfielded counts R camera
+MEDIAN_FFLAT_COUNT_R  float64       Median of fiber-flatfielded counts in R camera
+MEDIAN_FFLAT_SNR_R    float64       Median(S/N) of fiberflatfielded counts in R camera
+SUM_SKYSUB_COUNT_R    float64       Sum of sky-subtracted counts in R camera
+MEDIAN_SKYSUB_COUNT_R float64       Median of sky-subtracted counts in R camera
+MEDIAN_SKYSUB_SNR_R   float64       Median(S/N) of sky-subtracted counts in R camera
+SUM_CALIB_COUNT_R     float64       Sum of calibrated flux in R camera
+MEDIAN_CALIB_COUNT_R  float64       Median of calibrated flux in R camera
+MEDIAN_CALIB_SNR_R    float64       Median(S/N) of calibrated flux in R camera
+TSNR2_GPBDARK_R       float64       template (S/N)^2 for dark targets in guider pass band on R
 TSNR2_ELG_R           float64       ELG R template (S/N)^2
-TSNR2_GPBBRIGHT_R     float64
+TSNR2_GPBBRIGHT_R     float64       template (S/N)^2 for bright targets in guider pass band on R
 TSNR2_LYA_R           float64       LYA R template (S/N)^2
 TSNR2_BGS_R           float64       BGS R template (S/N)^2
 TSNR2_GPBBACKUP_R     float64
 TSNR2_QSO_R           float64       QSO R template (S/N)^2
 TSNR2_LRG_R           float64       LRG R template (S/N)^2
-SUM_RAW_COUNT_Z       float64
-MEDIAN_RAW_COUNT_Z    float64
-MEDIAN_RAW_SNR_Z      float64
-SUM_FFLAT_COUNT_Z     float64
-MEDIAN_FFLAT_COUNT_Z  float64
-MEDIAN_FFLAT_SNR_Z    float64
-SUM_SKYSUB_COUNT_Z    float64
-MEDIAN_SKYSUB_COUNT_Z float64
-MEDIAN_SKYSUB_SNR_Z   float64
-SUM_CALIB_COUNT_Z     float64
-MEDIAN_CALIB_COUNT_Z  float64
-MEDIAN_CALIB_SNR_Z    float64
-TSNR2_GPBDARK_Z       float64
+SUM_RAW_COUNT_Z       float64       Sum of raw counts in Z camera
+MEDIAN_RAW_COUNT_Z    float64       Median of raw counts in Z camera
+MEDIAN_RAW_SNR_Z      float64       Median(raw signal/noise) in Z camera
+SUM_FFLAT_COUNT_Z     float64       Sum of fiber-flatfielded counts Z camera
+MEDIAN_FFLAT_COUNT_Z  float64       Median of fiber-flatfielded counts in Z camera
+MEDIAN_FFLAT_SNR_Z    float64       Median(S/N) of fiberflatfielded counts in Z camera
+SUM_SKYSUB_COUNT_Z    float64       Sum of sky-subtracted counts in Z camera
+MEDIAN_SKYSUB_COUNT_Z float64       Median of sky-subtracted counts in Z camera
+MEDIAN_SKYSUB_SNR_Z   float64       Median(S/N) of sky-subtracted counts in Z camera
+SUM_CALIB_COUNT_Z     float64       Sum of calibrated flux in Z camera
+MEDIAN_CALIB_COUNT_Z  float64       Median of calibrated flux in Z camera
+MEDIAN_CALIB_SNR_Z    float64       Median(S/N) of calibrated flux in Z camera
+TSNR2_GPBDARK_Z       float64       template (S/N)^2 for dark targets in guider pass band on Z
 TSNR2_ELG_Z           float64       ELG Z template (S/N)^2
-TSNR2_GPBBRIGHT_Z     float64
+TSNR2_GPBBRIGHT_Z     float64       template (S/N)^2 for bright targets in guider pass band on Z
 TSNR2_LYA_Z           float64       LYA Z template (S/N)^2
 TSNR2_BGS_Z           float64       BGS Z template (S/N)^2
 TSNR2_GPBBACKUP_Z     float64
 TSNR2_QSO_Z           float64       QSO Z template (S/N)^2
 TSNR2_LRG_Z           float64       LRG Z template (S/N)^2
-===================== ======= ===== ======================
+===================== ======= ===== ============================================================
 
 HDU03
 -----
@@ -465,6 +463,19 @@ Required Header Keywords
     ====== ============= ==== =====================
 
 Data: FITS image [float32, 2751x11x500]
+
+A sparse resolution matrix may be created for spectrum ``i`` with::
+
+    from desispec.resolution import Resolution
+    R = Resolution(data[i])
+
+Or using lower-level scipy.sparse matrices::
+
+    import scipy.sparse
+    import numpy as np
+    nspec, ndiag, nwave = data.shape
+    offsets = ndiag//2 - np.arange(ndiag, dtype=int)
+    R = scipy.sparse.dia_matrix((data[i], offsets), shape=(nwave, nwave))
 
 HDU08
 -----

--- a/py/desidatamodel/data/column_descriptions.csv
+++ b/py/desidatamodel/data/column_descriptions.csv
@@ -1,5 +1,4 @@
 Name,Type,Units,Description
-A_MGII,float32,,Fitted parameter A (amplitude) by MgII fitter
 ABSMAG_R,float64,,Absolute magnitude in the r-band after k-correction
 AIRMASS,float32,,Average airmass during this exposure
 AIRMASS_GFA,float64,,Average airmass during this exposure as measured by GFA
@@ -9,18 +8,13 @@ APFLUX_IVAR_R,float32,nanomaggy^-2,Inverse variance of APFLUX_R
 APFLUX_IVAR_Z,float32,nanomaggy^-2,Inverse variance of APFLUX_Z
 APFLUX_R,float32,nanomaggy,Total flux in nanomaggies extracted in a 0.75 arcsec radius in the r band at this location
 APFLUX_Z,float32,nanomaggy,Total flux in nanomaggies extracted in a 0.75 arcsec radius in the z band at this location
-B_MGII,float32,,Fitted parameter B (constant) by MgII fitter
+A_MGII,float32,,Fitted parameter A (amplitude) by MgII fitter
 BGS_TARGET,int64,,BGS (Bright Galaxy Survey) target selection bitmask
 BITWEIGHTS,int64[2],,A size of two 64 bit masks that encodes which of the alternative assignment histories that the target was assigned in
-BRICK_OBJID,int32,,Imaging Surveys OBJID on that brick
 BRICKID,int32,,Brick ID from tractor input
 BRICKNAME,char[8],,Brick name from tractor input
-C_CIII,,,Confidence for CIII line
-C_CIV,,,Confidence for CIV line
-C_Halpha,,,Confidence for Halpha line
-C_Hbeta,,,Confidence for Hbeta line
-C_LYA,,,"Confidence for LyA line, i.e. ~probability to be a QSO"
-C_MgII,,,Confidence for MgII line
+BRICK_OBJID,int32,,Imaging Surveys OBJID on that brick
+B_MGII,float32,,Fitted parameter B (constant) by MgII fitter
 CHI2,float64,,Best fit chi squared
 CMX_TARGET,int64,,Target selection bitmask for commissioning
 COADD_EXPTIME,float32,s,Summed exposure time for coadd
@@ -30,13 +24,19 @@ COADD_NUMNIGHT,int16,,Number of nights in coadd
 COADD_NUMTILE,int16,,Number of tiles in coadd
 COEFF,float64[10],,Redrock template coefficients
 COMP_TILE,,,Assignment completeness for all targets of this type with the same value for TILES
+C_CIII,,,Confidence for CIII line
+C_CIV,,,Confidence for CIV line
+C_Halpha,,,Confidence for Halpha line
+C_Hbeta,,,Confidence for Hbeta line
+C_LYA,,,"Confidence for LyA line, i.e. ~probability to be a QSO"
+C_MgII,,,Confidence for MgII line
 DCHISQ,float32[5],,Difference in chi-squared between Tractor model fits
 DEC,float64,deg,Barycentric declination in ICRS
 DEC_IVAR,float32,deg^-2,"Inverse variance of DEC, excluding astrometric calibration errors"
+DELTACHI2,float64,,chi2 difference between first- and second-best redrock template fits
 DELTA_CHI2_MGII,,,chi2 diff between redrock model fit and MgII fit
 DELTA_X,float64,mm,CS5 X requested minus actual position
 DELTA_Y,float64,mm,CS5 Y requested minus actual position
-DELTACHI2,float64,,chi2 difference between first- and second-best redrock template fits
 DESI_TARGET,int64,,DESI (dark time program) target selection bitmask
 DEVICE_LOC,int32,,Device location on focal plane [0-523]
 DEVICE_TYPE,,,Device type
@@ -47,15 +47,11 @@ EQ_ALL_0P0,float64,,e-correction at redshift=0.0
 EQ_ALL_0P1,float64,,e-correction at redshift=0.1
 EXPID,int32,,DESI Exposure ID number
 EXPTIME,float64,s,Length of time shutter was open
+FAFLAVOR,char[*],,Fiberassign flavor name
+FAPRGRM,char[*],,Fiberassign program name
 FA_TARGET,int64,,Targeting bit internally used by fiberassign (linked with FA_TYPE)
 FA_TYPE,binary,,"Fiberassign internal target type (science, standard, sky, safe, suppsky)"
-FAPRGRM,char[*],,Fiberassign program name
-FAFLAVOR,char[*],,Fiberassign flavor name
 FIBER,int32,,Fiber ID on the CCDs [0-4999]
-FIBER_DEC,float64,deg,DEC of actual fiber position
-FIBER_RA,float64,deg,RA of actual fiber position
-FIBER_X,float64,mm,CS5 X location requested by PlateMaker
-FIBER_Y,float64,mm,CS5 Y location requested by PlateMaker
 FIBERASSIGN_X,float32,mm,Fiberassign expected CS5 X location on focal plane
 FIBERASSIGN_Y,float32,mm,Fiberassign expected CS5 Y location on focal plane
 FIBERFLUX_G,float32,nanomaggy,Predicted g-band flux within a fiber of diameter 1.5 arcsec from this object in 1 arcsec Gaussian seeing
@@ -65,6 +61,10 @@ FIBERSTATUS,,,Fiber status mask. 0=good
 FIBERTOTFLUX_G,float32,nanomaggy,Predicted g-band flux within a fiber of diameter 1.5 arcsec from all sources at this location in 1 arcsec Gaussian seeing
 FIBERTOTFLUX_R,float32,nanomaggy,Predicted r-band flux within a fiber of diameter 1.5 arcsec from all sources at this location in 1 arcsec Gaussian seeing
 FIBERTOTFLUX_Z,float32,nanomaggy,Predicted z-band flux within a fiber of diameter 1.5 arcsec from all sources at this location in 1 arcsec Gaussian seeing
+FIBER_DEC,float64,deg,DEC of actual fiber position
+FIBER_RA,float64,deg,RA of actual fiber position
+FIBER_X,float64,mm,CS5 X location requested by PlateMaker
+FIBER_Y,float64,mm,CS5 Y location requested by PlateMaker
 FLUX_G,float32,nanomaggy,Flux in the Legacy Survey g-band (AB)
 FLUX_G_DERED,float32,nanomaggy,Flux in the g-band after correcting for Galactic extinction (AB system)
 FLUX_IVAR_G,float32,nanomaggy^-2,Inverse variance of FLUX_G (AB)
@@ -81,24 +81,24 @@ FLUX_W2_DERED,float32,nanomaggy,Flux in the WISE W2-band after correcting for Ga
 FLUX_Z,float32,nanomaggy,Flux in the Legacy Survey z-band (AB)
 FLUX_Z_DERED,float32,nanomaggy,Flux in the z-band after correcting for Galactic extinction (AB system)
 FRACZ_TILELOCID,,,The fraction of targets of this type at this TILELOCID that received an observation (after forcing each target to a unique TILELOCID)
-GALDEPTH_G,float32,nanomaggy^-2,Galaxy model-based depth in LS g-band
-GALDEPTH_R,float32,nanomaggy^-2,Galaxy model-based depth in LS r-band
-GALDEPTH_Z,float32,nanomaggy^-2,Galaxy model-based depth in LS z-band
-GAIA_RA,,deg,Gaia ICRS right ascension
-GAIA_DEC,,deg,Gaia ICRS declination
-GAIA_PHOT_G_MEAN_MAG,float32,mag,Gaia G band magnitude
-GAIA_PHOT_G_MEAN_FLUX_OVER_ERROR,float32,,Gaia G band signal-to-noise
-GAIA_PHOT_BP_MEAN_MAG,float32,mag,Gaia BP band magnitude
-GAIA_PHOT_BP_MEAN_FLUX_OVER_ERROR,float32,,Gaia BP band signal-to-noise
-GAIA_PHOT_RP_MEAN_MAG,float32,mag,Gaia RP band magnitude
-GAIA_PHOT_RP_MEAN_FLUX_OVER_ERROR,float32,,Gaia RP band signal-to-noise
-GAIA_PHOT_BP_RP_EXCESS_FACTOR,float32,,Gaia BP/RP excess factor
 GAIA_ASTROMETRIC_EXCESS_NOISE,float32,,Gaia astrometric excess noise
-GAIA_DUPLICATED_SOURCE,bool,,Gaia duplicated source flag
-GAIA_ASTROMETRIC_SIGMA5D_MAX,float32,mas,Gaia longest semi-major axis of the 5-d error ellipsoid
 GAIA_ASTROMETRIC_PARAMS_SOLVED,int64,,which astrometric parameters were estimated for a Gaia source
+GAIA_ASTROMETRIC_SIGMA5D_MAX,float32,mas,Gaia longest semi-major axis of the 5-d error ellipsoid
+GAIA_DEC,,deg,Gaia ICRS declination
+GAIA_DUPLICATED_SOURCE,bool,,Gaia duplicated source flag
+GAIA_PHOT_BP_MEAN_FLUX_OVER_ERROR,float32,,Gaia BP band signal-to-noise
+GAIA_PHOT_BP_MEAN_MAG,float32,mag,Gaia BP band magnitude
+GAIA_PHOT_BP_RP_EXCESS_FACTOR,float32,,Gaia BP/RP excess factor
+GAIA_PHOT_G_MEAN_FLUX_OVER_ERROR,float32,,Gaia G band signal-to-noise
+GAIA_PHOT_G_MEAN_MAG,float32,mag,Gaia G band magnitude
+GAIA_PHOT_RP_MEAN_FLUX_OVER_ERROR,float32,,Gaia RP band signal-to-noise
+GAIA_PHOT_RP_MEAN_MAG,float32,mag,Gaia RP band magnitude
+GAIA_RA,,deg,Gaia ICRS right ascension
+GALDEPTH_G,float32,nanomaggy^-2,Galaxy model-based depth in LS g-band
 GALDEPTH_G,float32,nanomaggy^-2,Galaxy model-based depth in g-band
+GALDEPTH_R,float32,nanomaggy^-2,Galaxy model-based depth in LS r-band
 GALDEPTH_R,float32,nanomaggy^-2,Galaxy model-based depth in r-band
+GALDEPTH_Z,float32,nanomaggy^-2,Galaxy model-based depth in LS z-band
 GALDEPTH_Z,float32,nanomaggy^-2,Galaxy model-based depth in z-band
 GOODHARDLOC,,,True/False whether the fiber had good hardware
 GOODPRI,,,True/False whether the priority of what was assigned to the location was <= the base priority of the given target class
@@ -172,16 +172,41 @@ LC_NOBS_W2,int16[15],,NOBS_W2 in each of up to fifteen unWISE coadd epochs
 LOCATION,int64,,Location on the focal plane PETAL_LOC*1000 + DEVICE_LOC
 LOCATION_ASSIGNED,bool,,True/False for assigned/unassigned for the target in question
 LRG_MASK,binary,,Imaging mask bits relevant to LRG targets
+MAIN_NSPEC,int32,,Number of coadded spectra for this TARGETID in Main survey
+MAIN_PRIMARY,bool,,Boolean flag (True/False) for the primary coadded spectrum in Main survey
 MASKBITS,int16,,Bitwise mask from the imaging indicating potential issue or blending
 MEAN_DELTA_X,float32,mm,Mean (over exposures) fiber difference requested - actual CS5 X location on focal plane
 MEAN_DELTA_Y,float32,mm,Mean (over exposures) fiber difference requested - actual CS5 Y location on focal plane
 MEAN_FIBER_DEC,float64,deg,Mean (over exposures) DEC of actual fiber position
 MEAN_FIBER_RA,float64,deg,Mean (over exposures) RA of actual fiber position
-MAIN_NSPEC,int32,,Number of coadded spectra for this TARGETID in Main survey
-MAIN_PRIMARY,bool,,Boolean flag (True/False) for the primary coadded spectrum in Main survey
 MEAN_PSF_TO_FIBER_SPECFLUX,float32,,Mean of input exposures fraction of light from point-like source captured by 1.5 arcsec diameter fiber given atmospheric seeing
+MEDIAN_CALIB_COUNT_B,float64,,Median of calibrated flux in B camera
+MEDIAN_CALIB_COUNT_R,float64,,Median of calibrated flux in R camera
+MEDIAN_CALIB_COUNT_Z,float64,,Median of calibrated flux in Z camera
+MEDIAN_CALIB_SNR_B,float64,,Median(S/N) of calibrated flux in B camera
+MEDIAN_CALIB_SNR_R,float64,,Median(S/N) of calibrated flux in R camera
+MEDIAN_CALIB_SNR_Z,float64,,Median(S/N) of calibrated flux in Z camera
+MEDIAN_FFLAT_COUNT_B,float64,,Median of fiber-flatfielded counts in B camera
+MEDIAN_FFLAT_COUNT_R,float64,,Median of fiber-flatfielded counts in R camera
+MEDIAN_FFLAT_COUNT_Z,float64,,Median of fiber-flatfielded counts in Z camera
+MEDIAN_FFLAT_SNR_B,float64,,Median(S/N) of fiberflatfielded counts in B camera
+MEDIAN_FFLAT_SNR_R,float64,,Median(S/N) of fiberflatfielded counts in R camera
+MEDIAN_FFLAT_SNR_Z,float64,,Median(S/N) of fiberflatfielded counts in Z camera
+MEDIAN_RAW_COUNT_B,float64,,Median of raw counts in B camera
+MEDIAN_RAW_COUNT_R,float64,,Median of raw counts in R camera
+MEDIAN_RAW_COUNT_Z,float64,,Median of raw counts in Z camera
+MEDIAN_RAW_SNR_B,float64,,Median(raw signal/noise) in B camera
+MEDIAN_RAW_SNR_R,float64,,Median(raw signal/noise) in R camera
+MEDIAN_RAW_SNR_Z,float64,,Median(raw signal/noise) in Z camera
+MEDIAN_SKYSUB_COUNT_B,float64,,Median of sky-subtracted counts in B camera
+MEDIAN_SKYSUB_COUNT_R,float64,,Median of sky-subtracted counts in R camera
+MEDIAN_SKYSUB_COUNT_Z,float64,,Median of sky-subtracted counts in Z camera
+MEDIAN_SKYSUB_SNR_B,float64,,Median(S/N) of sky-subtracted counts in B camera
+MEDIAN_SKYSUB_SNR_R,float64,,Median(S/N) of sky-subtracted counts in R camera
+MEDIAN_SKYSUB_SNR_Z,float64,,Median(S/N) of sky-subtracted counts in Z camera
 MJD,float64,,Modified Julian Date when shutter was opened for this exposure
 MORPHTYPE,char[4],,Imaging Surveys morphological type from Tractor
+MWS_TARGET,int64,,Milky Way Survey targeting bits
 MW_TRANSMISSION_G,float32,,Milky Way dust transmission in LS g-band
 MW_TRANSMISSION_R,float32,,Milky Way dust transmission in LS r-band
 MW_TRANSMISSION_W1,float32,,Milky Way dust transmission in WISE W1
@@ -189,7 +214,6 @@ MW_TRANSMISSION_W2,float32,,Milky Way dust transmission in WISE W2
 MW_TRANSMISSION_W3,float32,,Milky Way dust transmission in WISE W3
 MW_TRANSMISSION_W4,float32,,Milky Way dust transmission in WISE W4
 MW_TRANSMISSION_Z,float32,,Milky Way dust transmission in LS z-band
-MWS_TARGET,int64,,Milky Way Survey targeting bits
 NCOEFF,int64,,Number of Redrock template coefficients
 NEAR_RADIUS,,arcsec,
 NIGHT,int32,,
@@ -198,27 +222,15 @@ NOBS_R,int16,,Number of images for central pixel in r-band
 NOBS_Z,int16,,Number of images for central pixel in z-band
 NPIXELS,int64,,Number of unmasked pixels contributing to the Redrock fit
 NTILE,,,Number of tiles target was available on
-NUM_ITER,int64,,Number of positioner iterations
 NUMOBS,int64,,"Number of spectroscopic observations (on this specific, single tile)"
 NUMOBS_INIT,int64,,Initial number of observations for target calculated across target selection bitmasks and OBSCONDITIONS
 NUMOBS_MORE,int64,,Number of additional observations needed
+NUM_ITER,int64,,Number of positioner iterations
 NZ,,,"The comoving number density of the tracer at the given redshift, in units (h/Mpc)^3, assuming complete sample"
 O2C,float64,,The criteria for assessing strength of OII emission for ELG observations
 OBJID,int32,,Imaging Surveys OBJID on that brick (renamed BRICK_OBJID)
 OBJTYPE,char[3],,"Object type: TGT, SKY, NON, BAD"
 OBSCONDITIONS,int32,,Bitmask of allowed observing conditions
-OII_CHI2,float32,,Reduced chi2 of the fit for the [OII] doublet
-OII_CONT,float32,10**-17 erg/(s cm2 Angstrom),Continuum used for the fitting (fixed value) for the [OII] doublet
-OII_CONT_IVAR,float32,10**+34 (s2 cm4 Angstrom2) / erg2,Inverse variance of the continuum for the [OII] doublet
-OII_EW,float32,Angstrom,Fitted rest-frame equivalent width for the [OII] doublet
-OII_EW_IVAR,float32,Angstrom^-2,Inverse variance of the fitted rest-frame equivalent width for the [OII] doublet
-OII_FLUX,float32,10**-17 erg/(s cm2),Fitted flux for the [OII] doublet
-OII_FLUX_IVAR,float32,10**+34 (s2 cm4) / erg2,Inverse variance of the fitted flux for the [OII] doublet
-OII_NDOF,int32,,Number of degrees of freedom of the fit for the [OII] doublet
-OII_SHARE,float32,,"Fitted F1/(F0+F1) for the [OII] doublet, where F0 and F1 are the individual line fluxes"
-OII_SHARE_IVAR,float32,,Inverse variance of the fitted F1/(F0+F1) for the [OII] doublet
-OII_SIGMA,float32,Angstrom,Fitted line width (in the observed frame) for the [OII] doublet
-OII_SIGMA_IVAR,float32,Angstrom^-2,Inverse variance of the fitted line width (in the observed frame) for the [OII] doublet
 OIII_CHI2,float32,,Reduced chi2 of the fit for the [OIII] doublet
 OIII_CONT,float32,10**-17 erg/(s cm2 Angstrom),Continuum used for the fitting (fixed value) for the [OIII] doublet
 OIII_CONT_IVAR,float32,10**+34 (s2 cm4 Angstrom2) / erg2,Inverse variance of the continuum for the [OIII] doublet
@@ -231,6 +243,18 @@ OIII_SHARE,float32,,"F1/(F0+F1) for the [OIII] doublet, where F0 and F1 are the 
 OIII_SHARE_IVAR,float32,,"Infinite value, as SHARE is fixed during the fit"
 OIII_SIGMA,float32,Angstrom,Fitted line width (in the observed frame) for the [OIII] doublet
 OIII_SIGMA_IVAR,float32,Angstrom^-2,Inverse variance of the fitted line width (in the observed frame) for the [OIII] doublet
+OII_CHI2,float32,,Reduced chi2 of the fit for the [OII] doublet
+OII_CONT,float32,10**-17 erg/(s cm2 Angstrom),Continuum used for the fitting (fixed value) for the [OII] doublet
+OII_CONT_IVAR,float32,10**+34 (s2 cm4 Angstrom2) / erg2,Inverse variance of the continuum for the [OII] doublet
+OII_EW,float32,Angstrom,Fitted rest-frame equivalent width for the [OII] doublet
+OII_EW_IVAR,float32,Angstrom^-2,Inverse variance of the fitted rest-frame equivalent width for the [OII] doublet
+OII_FLUX,float32,10**-17 erg/(s cm2),Fitted flux for the [OII] doublet
+OII_FLUX_IVAR,float32,10**+34 (s2 cm4) / erg2,Inverse variance of the fitted flux for the [OII] doublet
+OII_NDOF,int32,,Number of degrees of freedom of the fit for the [OII] doublet
+OII_SHARE,float32,,"Fitted F1/(F0+F1) for the [OII] doublet, where F0 and F1 are the individual line fluxes"
+OII_SHARE_IVAR,float32,,Inverse variance of the fitted F1/(F0+F1) for the [OII] doublet
+OII_SIGMA,float32,Angstrom,Fitted line width (in the observed frame) for the [OII] doublet
+OII_SIGMA_IVAR,float32,Angstrom^-2,Inverse variance of the fitted line width (in the observed frame) for the [OII] doublet
 PARALLAX,float32,mas,Reference catalog parallax
 PARALLAX_IVAR,float32,mas^-2,Inverse variance of PARALLAX
 PETAL_LOC,,,Petal location [0-9]
@@ -243,8 +267,8 @@ PMRA,float32,mas yr^-1,"proper motion in the +RA direction (already including co
 PMRA_IVAR,float32,yr^2 mas^-2,Inverse variance of PMRA
 PRIORITY,,,Target current priority
 PRIORITY_INIT,int64,,Target initial priority from target selection bitmasks and OBSCONDITIONS
-PROB_OBS,float64,,The number alternative assignment histories that the target was assigned in divided by 128
 PROBA_RF,,,
+PROB_OBS,float64,,The number alternative assignment histories that the target was assigned in divided by 128
 PROGRAM,char[6],,"DESI program type - BRIGHT, DARK, BACKUP, OTHER"
 PSFDEPTH_G,float32,nanomaggy^-2,PSF-based depth in g-band
 PSFDEPTH_R,float32,nanomaggy^-2,PSF-based depth in r-band
@@ -258,8 +282,8 @@ PSF_TO_FIBER_SPECFLUX,float64,,fraction of light from point-like source captured
 RA,float64,deg,Barycentric Right Ascension in ICRS
 RA_IVAR,float32,deg^-2,"Inverse variance of RA (no cosine term!), excluding astrometric calibration errors"
 REF_CAT,char[2],,"Reference catalog source for star: “T2” for Tycho-2, “G2” for Gaia DR2, “L2” for the SGA, empty otherwise"
-REF_ID,int64,,"Tyc1*1,000,000+Tyc2*10+Tyc3 for Tycho-2; “sourceid” for Gaia DR2"
 REF_EPOCH,float32,yr,Reference epoch for Gaia/Tycho astrometry. Typically 2015.5 for Gaia
+REF_ID,int64,,"Tyc1*1,000,000+Tyc2*10+Tyc3 for Tycho-2; “sourceid” for Gaia DR2"
 REF_MAG,,mag,
 RELEASE,int16,,Imaging surveys release ID
 REST_GMR_0P0,float64,,Rest-frame g-r colour at redshift=0.0
@@ -298,9 +322,19 @@ STD_FIBER_DEC,float32,arcsec,Standard deviation (over exposures) of DEC of actua
 STD_FIBER_RA,float32,arcsec,Standard deviation (over exposures) of RA of actual fiber position
 SUBPRIORITY,float64,,Random subpriority [0-1) to break assignment ties
 SUBTYPE,char[20],,Spectral subtype
+SUM_CALIB_COUNT_B,float64,,Sum of calibrated flux in B camera
+SUM_CALIB_COUNT_R,float64,,Sum of calibrated flux in R camera
+SUM_CALIB_COUNT_Z,float64,,Sum of calibrated flux in Z camera
+SUM_FFLAT_COUNT_B,float64,,Sum of fiber-flatfielded counts B camera
+SUM_FFLAT_COUNT_R,float64,,Sum of fiber-flatfielded counts R camera
+SUM_FFLAT_COUNT_Z,float64,,Sum of fiber-flatfielded counts Z camera
+SUM_RAW_COUNT_B,float64,,Sum of raw counts in B camera
+SUM_RAW_COUNT_R,float64,,Sum of raw counts in R camera
+SUM_RAW_COUNT_Z,float64,,Sum of raw counts in Z camera
+SUM_SKYSUB_COUNT_B,float64,,Sum of sky-subtracted counts in B camera
+SUM_SKYSUB_COUNT_R,float64,,Sum of sky-subtracted counts in R camera
+SUM_SKYSUB_COUNT_Z,float64,,Sum of sky-subtracted counts in Z camera
 SURVEY,char[7],,Survey name
-SV_NSPEC,int32,,Number of coadded spectra for this TARGETID in SV (SV1+2+3)
-SV_PRIMARY,bool,,Boolean flag (True/False) for the primary coadded spectrum in SV (SV1+2+3)
 SV1_BGS_TARGET,int64,,BGS (bright time program) target selection bitmask for SV1
 SV1_DESI_TARGET,int64,,DESI (dark time program) target selection bitmask for SV1
 SV1_MWS_TARGET,int64,,MWS (bright time program) target selection bitmask for SV1
@@ -313,15 +347,17 @@ SV3_BGS_TARGET,int64,,BGS (bright time program) target selection bitmask for SV3
 SV3_DESI_TARGET,int64,,DESI (dark time program) target selection bitmask for SV3
 SV3_MWS_TARGET,int64,,MWS (bright time program) target selection bitmask for SV3
 SV3_SCND_TARGET,int64,,Secondary target selection bitmask for SV3
+SV_NSPEC,int32,,Number of coadded spectra for this TARGETID in SV (SV1+2+3)
+SV_PRIMARY,bool,,Boolean flag (True/False) for the primary coadded spectrum in SV (SV1+2+3)
+TARGETID,int64,,Unique DESI target ID
 TARGET_DEC,float64,deg,Barycentric declination in ICRS
 TARGET_RA,float64,deg,Barycentric right ascension in ICRS
 TARGET_STATE,,,Combination of target class and its current observational state
-TARGETID,int64,,Unique DESI target ID
 TILEDEC,float64,deg,Barycentric declination of tile center in ICRS
 TILEID,int32,,Unique DESI tile ID
 TILELOCID,,,Is 10000*TILEID+LOCATION
-TILELOCID_ASSIGNED,,,0/1 for unassigned/assigned for TILELOCID in question (it could have been assigned to a different target)
 TILELOCIDS,,,"TILELOCIDs that the target was available for, separated by '-'"
+TILELOCID_ASSIGNED,,,0/1 for unassigned/assigned for TILELOCID in question (it could have been assigned to a different target)
 TILERA,float64,deg,Barycentric Right Ascension of tile center in ICRS
 TILES,str,,"TILEIDs of those tile, in string form separated by '-'"
 TIMESTAMP,str,s,UTC/ISO time at which the target state was updated
@@ -333,6 +369,14 @@ TSNR2_ELG,float32,,"ELG template (S/N)^2 summed over B,R,Z"
 TSNR2_ELG_B,float32,,ELG B template (S/N)^2
 TSNR2_ELG_R,float32,,ELG R template (S/N)^2
 TSNR2_ELG_Z,float32,,ELG Z template (S/N)^2
+TSNR2_GPBBRIGHT,float64,,template (S/N)^2 for bright targets in guider pass band
+TSNR2_GPBBRIGHT_B,float64,,template (S/N)^2 for bright targets in guider pass band on B
+TSNR2_GPBBRIGHT_R,float64,,template (S/N)^2 for bright targets in guider pass band on R
+TSNR2_GPBBRIGHT_Z,float64,,template (S/N)^2 for bright targets in guider pass band on Z
+TSNR2_GPBDARK,float64,,template (S/N)^2 for dark targets in guider pass band
+TSNR2_GPBDARK_B,float64,,template (S/N)^2 for dark targets in guider pass band on B
+TSNR2_GPBDARK_R,float64,,template (S/N)^2 for dark targets in guider pass band on R
+TSNR2_GPBDARK_Z,float64,,template (S/N)^2 for dark targets in guider pass band on Z
 TSNR2_LRG,float32,,"LRG template (S/N)^2 summed over B,R,Z"
 TSNR2_LRG_B,float32,,LRG B template (S/N)^2
 TSNR2_LRG_R,float32,,LRG R template (S/N)^2
@@ -361,6 +405,13 @@ WEIGHT_ZFAIL,float64,,Should be all 1 at this point for main survey
 WISEMASK_W1,byte,,Bitwise mask for WISE W1 data
 WISEMASK_W2,byte,,Bitwise mask for WISE W2 data
 Z,float64,,Redshift measured by Redrock
+ZCAT_NSPEC,int32,,Number of coadded spectra for this TARGETID in this zcatalog
+ZCAT_PRIMARY,bool,,Boolean flag (True/False) for the primary coadded spectrum in this zcatalog
+ZERR,float64,,Redshift error from redrock
+ZPOSSLOC,,,True/False whether the location could have been assigned to the given target class
+ZTILEID,int32,,ID of tile that most recently updated target's state
+ZWARN,int64,,Redshift warning bitmask from Redrock
+ZWARN_MTL,int64,,The ZWARN from the zmtl file (contains extra bits)
 Z_CIII,float64,,Redshift estimated by QuasarNET with CIII line
 Z_CIV,float64,,Redshift estimated by QuasarNET with CIV line
 Z_Halpha,float64,,Redshift estimated by QuasarNET with Halpha line
@@ -370,10 +421,3 @@ Z_MgII,float64,,Redshift estimated by QuasarNET with MgII line
 Z_QN,float64,,Redshift measured by QuasarNET using line with highest confidence
 Z_QN_CONF,float64,,Redshift confidence from QuasarNET
 Z_RR,float64,,Redshift collected from redrock file
-ZCAT_NSPEC,int32,,Number of coadded spectra for this TARGETID in this zcatalog
-ZCAT_PRIMARY,bool,,Boolean flag (True/False) for the primary coadded spectrum in this zcatalog
-ZERR,float64,,Redshift error from redrock
-ZPOSSLOC,,,True/False whether the location could have been assigned to the given target class
-ZTILEID,int32,,ID of tile that most recently updated target's state
-ZWARN,int64,,Redshift warning bitmask from Redrock
-ZWARN_MTL,int64,,The ZWARN from the zmtl file (contains extra bits)


### PR DESCRIPTION
This PR updates the datamodel for healpix- and tile-based spectra and coadd files, and their inputs/references (fibermap, frame, sframe, cframe).  I think this is sufficient to close #111  .