### PR TITLE
reorg for new users exploring data model

### DIFF
--- a/doc/DESIMODEL/index.rst
+++ b/doc/DESIMODEL/index.rst
@@ -2,7 +2,8 @@
 DESIMODEL
 =========
 
-:envvar:`DESIMODEL` points to the location of desimodel_ data.
+:envvar:`DESIMODEL` points to the location of desimodel_ files used to
+model the DESI instrument for data simulations.
 
 .. _desimodel: https://github.com/desihub/desimodel
 

--- a/doc/DESI_ROOT/index.rst
+++ b/doc/DESI_ROOT/index.rst
@@ -11,5 +11,7 @@ Subdirectories:
 .. toctree::
    :maxdepth: 1
 
+   spectro <../DESI_SPECTRO_REDUX/index>
    survey/index
+   target <../DESI_TARGET/index>
    vac/index

--- a/doc/DESI_ROOT/vac/RELEASE/index.rst
+++ b/doc/DESI_ROOT/vac/RELEASE/index.rst
@@ -7,7 +7,9 @@ particular data release. The value of ``RELEASE`` will typically be ``edr``, ``d
 
 Within this directory, each VAC will have a unique name.
 
-Subdirectories:
+Only some VACs include data model descriptions here;
+see https://data.desi.lbl.gov/doc/releases/edr/#value-added-catalogs
+for a full list of DESI Early Data Release VACs and their data models.
 
 .. toctree::
    :maxdepth: 1

--- a/doc/DESI_SPECTRO_CALIB/index.rst
+++ b/doc/DESI_SPECTRO_CALIB/index.rst
@@ -3,8 +3,9 @@ DESI_SPECTRO_CALIB
 ==================
 
 :envvar:`DESI_SPECTRO_CALIB` contains spectrographs calibration data.
+This directory tree is only partially documented here.
 
-Subdirectories:
+Files / subdirectories:
 
 .. toctree::
    :maxdepth: 1

--- a/doc/DESI_SPECTRO_DATA/NIGHT/EXPID/index.rst
+++ b/doc/DESI_SPECTRO_DATA/NIGHT/EXPID/index.rst
@@ -2,6 +2,12 @@
 EXPID
 =====
 
+| $DESI_SPECTRO_DATA/NIGHT/EXPID
+| Default $DESI_ROOT/spectro/data/NIGHT/EXPID
+
+``NIGHT`` is the night of observation in YYYYMMDD format.  The "night" roles
+over at noon local time, so all data taken between sunset and sunrise
+belong to the same night (i.e. the date of the sunset).
 ``EXPID`` is the 8-digit zero-padded exposure ID.
 
 Each exposure id (expid) generates multiple files:

--- a/doc/DESI_SPECTRO_DATA/NIGHT/EXPID/index.rst
+++ b/doc/DESI_SPECTRO_DATA/NIGHT/EXPID/index.rst
@@ -5,6 +5,8 @@ EXPID
 | $DESI_SPECTRO_DATA/NIGHT/EXPID
 | Default $DESI_ROOT/spectro/data/NIGHT/EXPID
 
+Raw data for each exposure of the DESI instrument.
+
 ``NIGHT`` is the night of observation in YYYYMMDD format.  The "night" roles
 over at noon local time, so all data taken between sunset and sunrise
 belong to the same night (i.e. the date of the sunset).

--- a/doc/DESI_SPECTRO_DATA/NIGHT/index.rst
+++ b/doc/DESI_SPECTRO_DATA/NIGHT/index.rst
@@ -2,6 +2,9 @@
 NIGHT
 =====
 
+| $DESI_SPECTRO_DATA/NIGHT
+| Default $DESI_ROOT/spectro/data/NIGHT
+
 ``NIGHT`` is the night of observation in YYYYMMDD format.  The "night" roles
 over at noon local time, so all data taken between sunset and sunrise
 belong to the same night (i.e. the date of the sunset). Under each night, data

--- a/doc/DESI_SPECTRO_DATA/index.rst
+++ b/doc/DESI_SPECTRO_DATA/index.rst
@@ -2,6 +2,8 @@
 DESI_SPECTRO_DATA
 =================
 
+Default $DESI_ROOT/spectro/data
+
 :envvar:`DESI_SPECTRO_DATA` contains raw data as produced by the telescope.
 The canonical location is ``$DESI_ROOT/spectro/data``, but one can set the
 environment variable :envvar:`DESI_SPECTRO_DATA` to point anywhere.

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/healpix/SURVEY/PROGRAM/PIXGROUP/PIXNUM/index.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/healpix/SURVEY/PROGRAM/PIXGROUP/PIXNUM/index.rst
@@ -2,13 +2,22 @@
 PIXNUM
 ======
 
+Default $DESI_ROOT/spectro/redux/SPECPROD/healpix/SURVEY/PROGRAM/PIXGROUP/PIXNUM
+
+  * SURVEY = sv1, sv3, main, ...
+  * PROGRAM = dark,bright,backup,other
+  * PIXNUM = nside 64 nested healpix number
+  * PIXGROUP = int(PIXNUM/100)
+
+Files:
+
 .. toctree::
    :maxdepth: 1
 
+   spectra-SURVEY-PROGRAM-PIXNUM
    coadd-SURVEY-PROGRAM-PIXNUM
+   redrock-SURVEY-PROGRAM-PIXNUM
    emline-SURVEY-PROGRAM-PIXNUM
    hpixexp-SURVEY-PROGRAM-PIXNUM
    qso_mgii-SURVEY-PROGRAM-PIXNUM
    qso_qn-SURVEY-PROGRAM-PIXNUM
-   redrock-SURVEY-PROGRAM-PIXNUM
-   spectra-SURVEY-PROGRAM-PIXNUM

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/index.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/index.rst
@@ -2,57 +2,31 @@
 SPECPROD
 ========
 
-Input files for spectroscopic reduction::
+Default $DESI_ROOT/spectro/redux/SPECPROD
 
-    $DESI_SPECTRO_DATA/{night}/
-        desi-{expid}.fits.fz
-        fibermap-{expid}.fits
+DESI spectroscopic data processing productions are grouped by spectroscopic
+production names (SPECPROD), named after mountains for data releases,
+e.g. "fuji" for the `Early Data Release <https://data.desi.lbl.gov/doc/releases/edr>`_.
 
-    $DESI_SPECTRO_SIM/{night}/
-        desi-{expid}.fits.fz
-        fibermap-{expid}.fits
-        pix-{camera}-{expid}.fits
-        simpix-{camera}-{expid}.fits
-        simspec-{expid}.fits
+Files in the top-level production directory:
 
-Output files::
+  * :doc:`exposures-SPECPROD.fits <exposures-SPECPROD>`: summary of exposures
+  * :doc:`tiles-SPECPROD.fits <tiles-SPECPROD>`: summary of tiles
+  
+Subdirectories under a spectroscopic production:
 
-    $DESI_SPECTRO_REDUX/$SPECPROD/
-        calibnight/{night}/
-            fiberflatnight-{camera}-{night}.fits
-            psfnight-{camera}-{night}.fits
-        exposures/{night}/{expid}/
-            cframe-{camera}-{expid}.fits
-            exposure-qa-{expid}.fits
-            fiberflat-{camera}-{expid}.fits
-            fit-psf-*-{camera}-{expid}.fits
-            fluxcalib-{camera}-{expid}.fits
-            frame-{camera}-{expid}.fits
-            psf-{camera}-{expid}.fits
-            sframe-{camera}-{expid}.fits
-            shifted-input-psf-{camera}-{expid}.fits
-            sky-{camera}-{expid}.fits
-            stdstars-{spectrograph}-{expid}.fits
-        healpix/
-            tilepix.fits
-        healpix/{survey}/{program}/{group}/{pixnum}/
-            coadd-{survey}-{program}-{pixnum}.fits
-            qso_mgii-{survey}-{program}-{pixnum}.fits
-            qso_qn-{survey}-{program}-{pixnum}.fits
-            redrock-{survey}-{program}-{pixnum}.fits
-            spectra-{survey}-{program}-{pixnum}.fits
-        preproc/{night}/{expid}/
-            fibermap-{expid}.fits
-            preproc-{camera}-{expid}.fits
-        tiles/
-            TBD
-        zcatalog/
-            zpix-{survey}-{program}.fits
-            ztile-{survey}-{program}-{tiletype}.fits
-
+  * :doc:`zcatalog/ <zcatalog/index>`: summary redshift catalogs
+  * :doc:`healpix/SURVEY/PROGRAM/PIXGROUP/PIXNUM <healpix/SURVEY/PROGRAM/PIXGROUP/PIXNUM/index>`:
+    spectra, classifications, and redshifts coadded across tiles, grouped by survey, program, and healpixel.
+  * :doc:`tiles/GROUPTYPE/TILEID/GROUPID/index <tiles/GROUPTYPE/TILEID/GROUPID/index>`:
+    spectra, classifications, and redshifts coadded per tile.
+  * :doc:`calibnight/NIGHT/ <calibnight/NIGHT/index>`: nightly calibrations
+  * :doc:`preproc/NIGHT/EXPID <preproc/NIGHT/EXPID/index>`: preprocessed spectrograph CCD images
+  * :doc:`exposures/NIGHT/EXPID <exposures/NIGHT/EXPID/index>`: per-exposure intermediate files
 
 .. toctree::
    :maxdepth: 1
+   :hidden:
 
    calibnight/index
    exposures/index

--- a/doc/DESI_SPECTRO_REDUX/index.rst
+++ b/doc/DESI_SPECTRO_REDUX/index.rst
@@ -2,6 +2,8 @@
 DESI_SPECTRO_REDUX
 ==================
 
+Default $DESI_ROOT/spectro/redux
+
 This directory contains production runs of the spectroscopic data reduction
 pipeline.  Each different run is contained in different SPECPROD subdirectory.
 

--- a/doc/DESI_SURVEYOPS/index.rst
+++ b/doc/DESI_SURVEYOPS/index.rst
@@ -1,9 +1,10 @@
-=========
-SURVEYOPS
-=========
+==============
+DESI_SURVEYOPS
+==============
 
-:envvar:`SURVEYOPS` contains data files used for day-to-day survey operations,
-with the canonical location of ``$DESI_ROOT/survey/ops/surveyops/trunk/``.
+:envvar:`DESI_SURVEYOPS` contains data files used for day-to-day survey operations,
+with the canonical location of ``$DESI_ROOT/survey/ops/surveyops/trunk/``,
+though data releases will use a tagged version.
 The main directory is an SVN trunk that is updated as the DESI survey proceeds.
 
 Subdirectories:

--- a/doc/DESI_TARGET/index.rst
+++ b/doc/DESI_TARGET/index.rst
@@ -2,10 +2,11 @@
 DESI_TARGET
 ===========
 
+Default $DESI_ROOT/target
+
 :envvar:`DESI_TARGET` contains target selection data (including information about
-secondary targets), and fiberassign data, with the canonical location of
-``$DESI_ROOT/TS/target``. Here, ``TS`` is, *e.g.*, ``public/ets`` for DESI early
-target selection. See also `Myers *et al.* (2023) <https://ui.adsabs.harvard.edu/abs/2023AJ....165...50M/abstract>`_.
+secondary targets), and fiberassign data.
+See also `Myers *et al.* (2023) <https://ui.adsabs.harvard.edu/abs/2023AJ....165...50M/abstract>`_.
 
 .. toctree::
    :maxdepth: 1

--- a/doc/PROTODESI/index.rst
+++ b/doc/PROTODESI/index.rst
@@ -2,6 +2,9 @@
 PROTODESI
 =========
 
+ProtoDESI was a DESI precursor program to test the DESI corrector and
+fiber positioning technology, albeit without spectra.
+
 :envvar:`PROTODESI` points to the location of ProtoDESI files.
 
 

--- a/doc/envvar.rst
+++ b/doc/envvar.rst
@@ -1,0 +1,23 @@
+=====================
+Environment Variables
+=====================
+
+DESI data are grouped broadly by category, using environment variables to
+define the base directory under which files of that category are kept.
+These variables have a standard location relative to :envvar:`DESI_ROOT`, but code
+uses these variables so that one can swap out different input/output locations
+for testing.
+
+.. toctree::
+   :maxdepth: 1
+
+   $DESI_ROOT : represents the top level of the DESI directory tree. <DESI_ROOT/index>
+   $DESI_SPECTRO_DATA : raw data <DESI_SPECTRO_DATA/index>
+   $DESI_SPECTRO_REDUX : processed spectro data <DESI_SPECTRO_REDUX/index>
+   $DESI_SPECTRO_SIM : simulated spectro data <DESI_SPECTRO_SIM/index>
+   $DESI_SPECTRO_CALIB : spectro calibration data <DESI_SPECTRO_CALIB/index>
+   $DESI_SURVEYOPS : data files used for day-to-day survey operations <DESI_SURVEYOPS/index>
+   $DESI_TARGET : target selection and fiber assignment (see also Myers et al. 2023) <DESI_TARGET/index>
+   $DESIMODEL : data used for simulating DESI <DESIMODEL/index>
+   $DESISURVEY_OUTPUT : outputs from desisurvey and surveysim <DESISURVEY_OUTPUT/index>
+   $PROTODESI : data and logs from the ProtoDESI campaign <PROTODESI/index>

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -5,15 +5,42 @@ Welcome to the DESI Data Model!
 The DESI Data Tree
 ------------------
 
-DESI data are grouped broadly by category, using environment variables to
-define the base directory under which files of that category are kept.
-These variables have a standard location relative to :envvar:`DESI_ROOT`, but code
-uses these variables so that one can swap out different input/output locations
-for testing.
+These pages define the directory structure and file formats for DESI
+data products relative to a root directory :envvar:`DESI_ROOT`.
+Each data release has its own :envvar:`DESI_ROOT`, e.g. the
+`Early Data Release <https://data.desi.lbl.gov/doc/releases/edr/>`_
+at https://data.desi.lbl.gov/public/edr.
+
+Data Directories
+================
+
+Directories under DESI_ROOT
+
+   * `spectro/data/NIGHT/EXPID/ <DESI_SPECTRO_DATA/NIGHT/EXPID/index.html>`_: Raw data 
+   * `spectro/redux/SPECPROD/ <DESI_SPECTRO_REDUX/SPECPROD/index.html>`_: Processed spectra, classifications, and redshifts 
+   * `target/ <DESI_TARGET/index.html>`_: Target selection and fiber assignment catalogs
+   * `vac/RELEASE/ <DESI_ROOT/vac/RELEASE/index.html>`_: Value Added Catalogs
+
+The following directories are more expert-level (e.g. pipeline calibration inputs)
+and are documented for DESI collaboration internal use and may not be included
+in data releases:
+
+   * `survey/ops/surveyops/ <DESI_SURVEYOPS/index.html>`_: Data files used for day-to-day survey operations
+   * `spectro/desi_spectro_calib/ <DESI_SPECTRO_CALIB/index.html>`_: Spectrograph calibration data
+   * `protodesi/ <PROTODESI/index.html>`_: Data and logs from the ProtoDESI campaign (no spectra)
+   * `$DESISURVEY_OUTPUT <DESISURVEY_OUTPUT/index.html>`_: Outputs from desisurvey and surveysim
+   * `$DESI_SPECTRO_SIM <DESI_SPECTRO_SIM/index.html>`_: Simulated spectro data
+   * `$DESIMODEL <DESIMODEL/index.html>`_: Data used for simulating DESI
+
+
+.. comment: the following toctree items exist to keep sphinx happy, but
+   are purposefully hidden (e.g. because the text above links
+   a level deeper)
 
 .. toctree::
-   :maxdepth: 1
-
+   :hidden:
+   
+   vac/ : Value Added Catalogs <DESI_ROOT/vac/index>
    $DESI_ROOT : represents the top level of the DESI directory tree. <DESI_ROOT/index>
    $DESI_SPECTRO_DATA : raw data <DESI_SPECTRO_DATA/index>
    $DESI_SPECTRO_REDUX : processed spectro data <DESI_SPECTRO_REDUX/index>
@@ -24,10 +51,16 @@ for testing.
    $DESIMODEL : data used for simulating DESI <DESIMODEL/index>
    $DESISURVEY_OUTPUT : outputs from desisurvey and surveysim <DESISURVEY_OUTPUT/index>
    $PROTODESI : data and logs from the ProtoDESI campaign <PROTODESI/index>
+
+
+Other information
+=================
+
+.. toctree::
+   :maxdepth: 1
+
    bitmasks
-   datamodel
-   api
-   changes
+   Environment variables <envvar>
 
 Imaging data and their catalogs are documented separately by the
 `Legacy Survey <https://www.legacysurvey.org/>`_.
@@ -35,17 +68,26 @@ Imaging data and their catalogs are documented separately by the
 The desidatamodel_ package on GitHub includes the data model input files
 and some Python utility code for generating and checking data model files.
 
+.. toctree::
+   :maxdepth: 1
+
+   datamodel
+   api
+   changes
+
+
 .. _desidatamodel: https://github.com/desihub/desidatamodel
 
 References
 ----------
 
-`Myers, A. D., et al., AJ 165, 50, 2023 <https://ui.adsabs.harvard.edu/abs/2023AJ....165...50M/abstract>`_
+  * Target Selection: `Myers, A. D., et al. 2023, AJ 165, 50 <https://ui.adsabs.harvard.edu/abs/2023AJ....165...50M/abstract>`_
+  * Spectroscopic Pipeline: `Guy, J., et al. 2023, AJ 165, 4, 144 <https://ui.adsabs.harvard.edu/abs/2023AJ....165..144G/abstract>`_
+  * Early Data Release: **TODO: arxiv link**
 
-Indices and Tables
-------------------
+Index and Search Pages
+----------------------
 
 * :ref:`genindex`
-* :ref:`modindex`
 * :ref:`search`
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -14,23 +14,23 @@ at https://data.desi.lbl.gov/public/edr.
 Data Directories
 ================
 
-Directories under DESI_ROOT
+Directories under :envvar:`DESI_ROOT`:
 
-   * `spectro/data/NIGHT/EXPID/ <DESI_SPECTRO_DATA/NIGHT/EXPID/index.html>`_: Raw data 
-   * `spectro/redux/SPECPROD/ <DESI_SPECTRO_REDUX/SPECPROD/index.html>`_: Processed spectra, classifications, and redshifts 
-   * `target/ <DESI_TARGET/index.html>`_: Target selection and fiber assignment catalogs
-   * `vac/RELEASE/ <DESI_ROOT/vac/RELEASE/index.html>`_: Value Added Catalogs
+   * :doc:`spectro/data/NIGHT/EXPID/ <DESI_SPECTRO_DATA/NIGHT/EXPID/index>`: Raw data 
+   * :doc:`spectro/redux/SPECPROD/ <DESI_SPECTRO_REDUX/SPECPROD/index>`: Processed spectra, classifications, and redshifts 
+   * :doc:`target/ <DESI_TARGET/index>`: Target selection and fiber assignment catalogs
+   * :doc:`vac/RELEASE/ <DESI_ROOT/vac/RELEASE/index>`: Value Added Catalogs
 
 The following directories are more expert-level (e.g. pipeline calibration inputs)
 and are documented for DESI collaboration internal use and may not be included
 in data releases:
 
-   * `survey/ops/surveyops/ <DESI_SURVEYOPS/index.html>`_: Data files used for day-to-day survey operations
-   * `spectro/desi_spectro_calib/ <DESI_SPECTRO_CALIB/index.html>`_: Spectrograph calibration data
-   * `protodesi/ <PROTODESI/index.html>`_: Data and logs from the ProtoDESI campaign (no spectra)
-   * `$DESISURVEY_OUTPUT <DESISURVEY_OUTPUT/index.html>`_: Outputs from desisurvey and surveysim
-   * `$DESI_SPECTRO_SIM <DESI_SPECTRO_SIM/index.html>`_: Simulated spectro data
-   * `$DESIMODEL <DESIMODEL/index.html>`_: Data used for simulating DESI
+   * :doc:`survey/ops/surveyops/ <DESI_SURVEYOPS/index>`: Data files used for day-to-day survey operations
+   * :doc:`spectro/desi_spectro_calib/ <DESI_SPECTRO_CALIB/index>`: Spectrograph calibration data
+   * :doc:`protodesi/ <PROTODESI/index>`: Data and logs from the ProtoDESI campaign (no spectra)
+   * :doc:`$DESISURVEY_OUTPUT <DESISURVEY_OUTPUT/index>`: Outputs from desisurvey and surveysim
+   * :doc:`$DESI_SPECTRO_SIM <DESI_SPECTRO_SIM/index>`: Simulated spectro data
+   * :doc:`$DESIMODEL <DESIMODEL/index>`: Data used for simulating DESI
 
 
 .. comment: the following toctree items exist to keep sphinx happy, but
@@ -56,6 +56,8 @@ in data releases:
 Other information
 =================
 
+Bitmask definitions and environment variables used by the DESI data pipelines:
+
 .. toctree::
    :maxdepth: 1
 
@@ -67,6 +69,7 @@ Imaging data and their catalogs are documented separately by the
 
 The desidatamodel_ package on GitHub includes the data model input files
 and some Python utility code for generating and checking data model files.
+These links will be useful for developers:
 
 .. toctree::
    :maxdepth: 1

--- a/py/desidatamodel/data/column_descriptions.csv
+++ b/py/desidatamodel/data/column_descriptions.csv
@@ -246,7 +246,7 @@ O2C,float64,,The criteria for assessing strength of OII emission for ELG observa
 OBJID,int32,,Imaging Surveys OBJID on that brick (renamed BRICK_OBJID)
 OBJTYPE,char[3],,"Object type: TGT, SKY, NON, BAD"
 OBSCONDITIONS,int32,,Bitmask of allowed observing conditions
-OCLAYER,char[6],,Either "DARK" for dark-time or "BRIGHT" to observe in either bright- or dark-time
+OCLAYER,char[6],,"Either 'DARK' for dark-time or 'BRIGHT' to observe in either bright- or dark-time"
 OIII_CHI2,float32,,Reduced chi2 of the fit for the [OIII] doublet
 OIII_CONT,float32,10**-17 erg/(s cm2 Angstrom),Continuum used for the fitting (fixed value) for the [OIII] doublet
 OIII_CONT_IVAR,float32,10**+34 (s2 cm4 Angstrom2) / erg2,Inverse variance of the continuum for the [OIII] doublet

--- a/py/desidatamodel/data/column_descriptions.csv
+++ b/py/desidatamodel/data/column_descriptions.csv
@@ -383,7 +383,7 @@ TILES,char[*],,"TILEIDs of those tile, in string form separated by '-'"
 TIMESTAMP,str,s,UTC/ISO time at which the target state was updated
 TOOID,int64,,ID for this target assigned by the ``CHECKER``
 TOO_PRIO,char[2],,"Either 'HI' for a very-high-priority target or 'LO' for a very-low-priority target"
-TOO_TYPE,char[5],,Either "TILE" for a special tile or "FIBER" for a fiber-override ToO
+TOO_TYPE,char[5],,"Either 'TILE' for a special tile or 'FIBER' for a fiber-override ToO"
 TSNR2_BGS,float32,,"BGS template (S/N)^2 summed over B,R,Z"
 TSNR2_BGS_B,float32,,BGS B template (S/N)^2
 TSNR2_BGS_R,float32,,BGS R template (S/N)^2

--- a/py/desidatamodel/data/column_descriptions.csv
+++ b/py/desidatamodel/data/column_descriptions.csv
@@ -382,7 +382,7 @@ TILERA,float64,deg,Barycentric Right Ascension of tile center in ICRS
 TILES,char[*],,"TILEIDs of those tile, in string form separated by '-'"
 TIMESTAMP,str,s,UTC/ISO time at which the target state was updated
 TOOID,int64,,ID for this target assigned by the ``CHECKER``
-TOO_PRIO,char[2],,Either "HI" for a very-high-priority target or "LO" for a very-low-priority target
+TOO_PRIO,char[2],,"Either 'HI' for a very-high-priority target or 'LO' for a very-low-priority target"
 TOO_TYPE,char[5],,Either "TILE" for a special tile or "FIBER" for a fiber-override ToO
 TSNR2_BGS,float32,,"BGS template (S/N)^2 summed over B,R,Z"
 TSNR2_BGS_B,float32,,BGS B template (S/N)^2


### PR DESCRIPTION
This PR is a work in progress to reorganize the data model presentation to be more oriented towards new users exploring the datamodel and directory tree, rather than expert developers:
  * Top level landing page splits most commonly used directories (e.g. spectro/redux/ and target/) from historical/expert directories (like protodesi/)
  * Non-directory things (like mask bits) get their own bullet list section instead of being mixed in with directories.
  * Landing page and descriptions emphasize the default path relative to $DESI_ROOT rather than the expert-level environment variables (e.g. $DESI_ROOT/spectro/redux over $DESI_SPECTRO_REDUX).
  * The environment variables that point to subdirs under $DESI_ROOT are moved to a separate page rather than being the primary starting point, since most new users won't know what $DESI_SPECTRO_REDUX is how how it relates to the EDR root directory.

So far I've just updated the landing page and the $DESI_ROOT/spectro/data tree (while admitting that isn't the most commonly used dir by end-users).  I'm posting this PR as a WIP now so that others (especially @weaverba137) can look and comment if needed before I spend too much more time adding similar changes to the DESI_SPECTRO_REDUX tree.

Other than the addition of envvars.rst, this PR (and future updates to it) only modifies index.rst files, not the core directory structure nor the data model files themselves.