### PR TITLE
Add details about units in FITS files

### DIFF
--- a/bin/update_bitmasks
+++ b/bin/update_bitmasks
@@ -27,8 +27,8 @@ The **ZWARN** bitmask in redshift catalogs indicates known problems with a
 particular redshift fit or associated QA.
 ZWARN==0 is good; any non-zero value indicates a potential problem.
 This mask will be described in more detail in the Redrock paper
-(Bailey et al 2023 in prep), as well as Section 5.3.1 of the
-Survey Operations Paper (Schlafly et al 2023 TODO: add link).
+(Bailey et al. 2023 in prep), as well as Section 5.3.1 of the
+Survey Operations Paper (`Schlafly et al. 2023 <https://arxiv.org/abs/2306.06309>`_).
 
 The canonical code location defining these bits is
 `desitarget targetmask.yaml <https://github.com/desihub/desitarget/blob/main/py/desitarget/data/targetmask.yaml#L230>`_.
@@ -173,7 +173,7 @@ TARGETS, FIBERASSIGN, and FIBERMAP tables in data files.
 These masks are described in more detail in Section 2 of
 `Myers et al. (2023) <https://ui.adsabs.harvard.edu/abs/2023AJ....165...50M/abstract>`_
 and Appendices A and B of the the DESI EDR Overview paper
-(DESI Collaboration et al 2023 TODO: add link).
+(`DESI Collaboration et al. 2023 <https://arxiv.org/abs/2306.06308>`_).
 
 The following table lists a subset of the most commonly used bits that maintained
 the same definition throughout different phases of DESI observations.  For the

--- a/doc/DESI_ROOT/vac/RELEASE/lss/VERSION/LSScats/clustering/index.rst
+++ b/doc/DESI_ROOT/vac/RELEASE/lss/VERSION/LSScats/clustering/index.rst
@@ -6,19 +6,19 @@ clustering
 
 ``clustering`` contains LSS catalogs, separated by target types (:ref:`see here for references<lsscats>`), that have been prepared to be used directly to obtain clustering statistics. It includes both data for randoms (separated into 18 files given ``{RANN}``).
 
-Descriptions on how to use these to obtain clustering measurements are fully given in `EDR. DESI Collaboration (in prep.)`_ and in `Lasker et al (in prep.)`_. Any cuts applied to the data catalogs should be equally applied to the random catalogs. 
+Descriptions on how to use these to obtain clustering measurements are fully given in `EDR. DESI Collaboration (in prep.)`_ and in `Lasker et al (in prep.)`_. Any cuts applied to the data catalogs should be equally applied to the random catalogs.
 
-Any number of the random catalogs, ``{RANN}`` can be used (with the impact only on statistical precision). Large-scale clustering measurements can be accurately obtained via the columns :py:attr:`RA`, :py:attr:`DEC`, :py:attr:`Z`, :py:attr:`WEIGHT`. 
+Any number of the random catalogs, ``{RANN}`` can be used (with the impact only on statistical precision). Large-scale clustering measurements can be accurately obtained via the columns :py:attr:`RA`, :py:attr:`DEC`, :py:attr:`Z`, :py:attr:`WEIGHT`.
 
 For small-scales, pairwise inverse-probability (PIP) weights can be obtained via the BITWEIGHTS column and we further recommend angular up-weighting (as in `Mohammad et al. (2020)`_). If using PIP weights, the :py:attr:`WEIGHT` column should still be used for the random counts (but not used for the data counts).
 
-.. _EDR. DESI Collaboration (in prep.): https://ui.adsabs.harvard.edu/public-libraries/XCj7bW-vSMaNZVV0C0QyGA
+.. _EDR. DESI Collaboration (in prep.): https://arxiv.org/abs/2306.06308
 .. _Lasker et al (in prep.): https://ui.adsabs.harvard.edu/public-libraries/XCj7bW-vSMaNZVV0C0QyGA
 .. _Mohammad et al. (2020): https://academic.oup.com/mnras/article/498/1/128/5891251
 
 .. toctree::
    :maxdepth: 1
 
-   TARGET_PHOTSYS_RANN_clustering.ran.fits : Use for clustering measurements (randoms) <clustering_ran>  
+   TARGET_PHOTSYS_RANN_clustering.ran.fits : Use for clustering measurements (randoms) <clustering_ran>
    TARGET_PHOTSYS_clustering.dat.fits : Use for clustering measurements (data) <clustering_dat>
 

--- a/doc/DESI_ROOT/vac/RELEASE/lss/VERSION/LSScats/index.rst
+++ b/doc/DESI_ROOT/vac/RELEASE/lss/VERSION/LSScats/index.rst
@@ -7,20 +7,20 @@ LSScats
 
 ``$DESI_ROOT/vac/RELEASE/lss/SPECPROD/SURVEY/VERSION/LSScats`` contains the directories for ``full`` (including information on all targets) and ``clustering`` (only information needed for clustering measurements and weights/cuts to optimize those clustering measurements). Files detailing the estimated n(z) in units of (h/Mpc)^3 are also here.
 
-Catalogs were created for the four extra-galactic DESI target types: LRG, ELG, QSO, and BGS. For all except QSO, catalogs are produced for additional sub-type definitions. In the cases where the sub-type corresponds to a bitname from `SV3 targeting`_, we use that name: 
+Catalogs were created for the four extra-galactic DESI target types: LRG, ELG, QSO, and BGS. For all except QSO, catalogs are produced for additional sub-type definitions. In the cases where the sub-type corresponds to a bitname from `SV3 targeting`_, we use that name:
 
-* The additional LRG selection, named LRG_main, keeps only targets that satisfy the main survey selection (see `Zhou et al. (2022)`_ for details). 
+* The additional LRG selection, named LRG_main, keeps only targets that satisfy the main survey selection (see `Zhou et al. (2022)`_ for details).
 
-* The ELG sample is cut in three additional ways. First, ELG_HIP contains only the ~75% of the ELG sample that is at higher priority (see `Raichoor et al. (2022)`_ for more details). Then, for each of ELG and ELG_HIP, we also remove QSO targets. 
+* The ELG sample is cut in three additional ways. First, ELG_HIP contains only the ~75% of the ELG sample that is at higher priority (see `Raichoor et al. (2022)`_ for more details). Then, for each of ELG and ELG_HIP, we also remove QSO targets.
 
-* QSO targets have the highest priority and one may wish to therefore treat any targets that satisfy both the QSO and ELG selections within the QSO analysis. 
+* QSO targets have the highest priority and one may wish to therefore treat any targets that satisfy both the QSO and ELG selections within the QSO analysis.
 
-* Finally, there are two BGS samples: BGS_ANY and BGS_BRIGHT. BGS_ANY is the combination of both the BGS_BRIGHT and BGS_FAINT BGS selections. See `Hahn et al. (2022)`_ for more details.
+* Finally, there are two BGS samples: BGS_ANY and BGS_BRIGHT. BGS_ANY is the combination of both the BGS_BRIGHT and BGS_FAINT BGS selections. See `Hahn et al. (2023)`_ for more details.
 
 .. _SV3 targeting: https://github.com/desihub/desitarget/blob/2.5.0/py/desitarget/sv3/data/sv3_targetmask.yaml
 .. _Zhou et al. (2022): https://iopscience.iop.org/article/10.3847/1538-3881/aca5fb
 .. _Raichoor et al. (2022): https://iopscience.iop.org/article/10.3847/1538-3881/acb213
-.. _Hahn et al. (2022): https://arxiv.org/abs/2208.08512
+.. _Hahn et al. (2023): https://iopscience.iop.org/article/10.3847/1538-3881/accff8
 
 .. toctree::
    :maxdepth: 1

--- a/doc/DESI_ROOT/vac/RELEASE/lss/index.rst
+++ b/doc/DESI_ROOT/vac/RELEASE/lss/index.rst
@@ -2,18 +2,18 @@
 lss
 ===
 
-``$DESI_ROOT/vac/RELEASE/lss`` contains LSS catalogs reading from most other DESI products, ready for archiving with 
-the early data release. Intermediate files are saved, until we build the clustering-ready catalogs 
-(including weights). 
+``$DESI_ROOT/vac/RELEASE/lss`` contains LSS catalogs reading from most other DESI products, ready for archiving with
+the early data release. Intermediate files are saved, until we build the clustering-ready catalogs
+(including weights).
 
 ``VERSION`` contains different possible versions of the LSS catalogs, given a production run and a tile selection. As of the EDR release date, there is one single version named ``v2.0`` (we use v2.0 in order to distinguish these catalogs from an internal DESI earlier v1.0 version).
 
-The final clustering-ready catalogs can be found under :ref:`LSScats/clustering<clustering>`, together with the random samples for the same target types. 
+The final clustering-ready catalogs can be found under :ref:`LSScats/clustering<clustering>`, together with the random samples for the same target types.
 Information about the different target types and the use of the different weights can be found in `EDR. DESI Collaboration (in prep.)`_ and in the explanation of :ref:`LSScats<lsscats>` subdirectory.
 
 The catalogs are generated using tools from github_lss_repository_. For EDR we use the `github release tag v2.0.0-EDR`_
 
-.. _EDR. DESI Collaboration (in prep.): https://ui.adsabs.harvard.edu/public-libraries/XCj7bW-vSMaNZVV0C0QyGA
+.. _EDR. DESI Collaboration (in prep.): https://arxiv.org/abs/2306.06308
 
 .. _github_lss_repository: https://github.com/desihub/LSS
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,9 @@ desidatamodel Change Log
 23.6 (unreleased)
 -----------------
 
-* No changes yet.
+* Add note about units in FITS files (PR `#178`_).
+
+.. _`#178`: https://github.com/desihub/desidatamodel/pull/178
 
 23.1 (2023-06-12)
 -----------------

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -63,6 +63,7 @@ Bitmask definitions and environment variables used by the DESI data pipelines:
 
    bitmasks
    Environment variables <envvar>
+   Units in data files <units>
 
 Imaging data and their catalogs are documented separately by the
 `Legacy Survey <https://www.legacysurvey.org/>`_.

--- a/doc/units.rst
+++ b/doc/units.rst
@@ -1,0 +1,28 @@
+===================
+Units in Data Files
+===================
+
+In the DESI data model, wherever possible we describe the units carried by
+values in the data files being described. In some cases the values are actually
+dimensionless, or a simple quantity such as wavelength (``Angstrom``). In
+other cases the units are more complex such as spectral flux density
+(``10^-17 erg cm^-2 s^-1 Angstrom^-1``).
+
+The majority of the files in the DESI data set are `FITS files`_.  The
+FITS standard supports header keywords that describe the units of the
+values stored in each HDU. A ``BUNIT`` keyword describes the units for an
+image HDU, while ``TUNITn`` keywords describe the units of column ``n`` in
+a table HDU.  In the DESI data model, we specify units that follow FITS
+standards as closely as possible. See Section 4.3 of the
+`FITS Standard (Version 4.0)`_ for more details.
+
+However, even though units are described in this data model, it is not always
+the case that units are specified in the FITS files themselves. In other words,
+``BUNIT`` or ``TUNITn`` header keywords are not always present.
+If you routinely read FITS files with QTable_, for example, the described units
+might not appear automatically.
+
+
+.. _`FITS files`: https://fits.gsfc.nasa.gov
+.. _`FITS Standard (Version 4.0)`: https://fits.gsfc.nasa.gov/standard40/fits_standard40aa-le.pdf
+.. _`QTable`: https://docs.astropy.org/en/stable/api/astropy.table.QTable.html#astropy.table.QTable


### PR DESCRIPTION
This PR adds a caveat about units in FITS files.  Also, unrelated, I realized I added the EDR and other paper links to the `bitmasks.rst` file when they should have been added to the template in `update_bitmasks`. This is also fixed now.