### PR TITLE
Migrate units to desiutil

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -23,11 +23,11 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
                 fetch-depth: 0
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v4
               with:
                 python-version: ${{ matrix.python-version }}
             - name: Install Python dependencies
@@ -52,11 +52,11 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
                 fetch-depth: 0
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v4
               with:
                 python-version: ${{ matrix.python-version }}
             - name: Install Python dependencies
@@ -86,11 +86,11 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
                 fetch-depth: 0
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v4
               with:
                 python-version: ${{ matrix.python-version }}
             - name: Install Python dependencies
@@ -116,11 +116,11 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
                 fetch-depth: 0
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v4
               with:
                 python-version: ${{ matrix.python-version }}
             - name: Install Python dependencies
@@ -144,11 +144,11 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v2
+              uses: actions/checkout@v3
               with:
                 fetch-depth: 0
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v4
               with:
                 python-version: ${{ matrix.python-version }}
             - name: Install Python dependencies

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,7 +19,7 @@ jobs:
                 os: [ubuntu-latest]
                 python-version: ['3.9', '3.10']  #, '3.11'] possible conflicts between numpy & astropy on 3.11.
                 astropy-version: ['<5.1', '<5.3', '<6.0']
-                desiutil-version: ['3.3.1', 'migrate-units']
+                desiutil-version: ['3.3.1', 'main']
 
         steps:
             - name: Checkout code

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,7 +19,7 @@ jobs:
                 os: [ubuntu-latest]
                 python-version: ['3.9', '3.10']  #, '3.11'] possible conflicts between numpy & astropy on 3.11.
                 astropy-version: ['<5.1', '<5.3', '<6.0']
-                desiutil-version: ['3.3.0']
+                desiutil-version: ['3.3.1', 'migrate-units']
 
         steps:
             - name: Checkout code

--- a/doc/DESI_ROOT/survey/fiberassign/SURVEY/TILEXX/TILEID-gfa.rst
+++ b/doc/DESI_ROOT/survey/fiberassign/SURVEY/TILEXX/TILEID-gfa.rst
@@ -82,7 +82,7 @@ FLUX_IVAR_G                       float32 nanomaggy^-2 Inverse variance of FLUX_
 FLUX_IVAR_R                       float32 nanomaggy^-2 Inverse variance of FLUX_R (AB)
 FLUX_IVAR_Z                       float32 nanomaggy^-2 Inverse variance of FLUX_Z (AB)
 REF_ID                            int64                Tyc1*1,000,000+Tyc2*10+Tyc3 for Tycho-2; ``sourceid`` for Gaia DR2
-REF_CAT                           char[2]              Reference catalog source for star: &#x27;T2&#x27; for Tycho-2, &#x27;G2&#x27; for Gaia DR2, &#x27;L2&#x27; for the SGA, empty otherwise
+REF_CAT                           char[2]              Reference catalog source for star: 'T2' for Tycho-2, 'G2' for Gaia DR2, 'L2' for the SGA, empty otherwise
 REF_EPOCH                         float32 yr           Reference epoch for Gaia/Tycho astrometry. Typically 2015.5 for Gaia
 PARALLAX                          float32 mas          Reference catalog parallax
 PARALLAX_IVAR                     float32 mas^-2       Inverse variance of PARALLAX

--- a/doc/DESI_ROOT/survey/fiberassign/SURVEY/TILEXX/TILEID-scnd.rst
+++ b/doc/DESI_ROOT/survey/fiberassign/SURVEY/TILEXX/TILEID-scnd.rst
@@ -91,7 +91,7 @@ NUMOBS_MORE           int64              Number of additional observations neede
 NUMOBS                int64              Number of spectroscopic observations (on this specific, single tile)
 Z                     float64            Redshift measured by Redrock
 ZWARN                 int64              Redshift warning bitmask from Redrock
-ZTILEID               int32              ID of tile that most recently updated target&#x27;s state
+ZTILEID               int32              ID of tile that most recently updated target's state
 Z_QN                  float64            Redshift measured by QuasarNET using line with highest confidence
 IS_QSO_QN             int16              Spectroscopic classification from QuasarNET (1 for a quasar)
 DELTACHI2             float64            chi2 difference between first- and second-best redrock template fits

--- a/doc/DESI_ROOT/survey/fiberassign/SURVEY/TILEXX/TILEID-targ.rst
+++ b/doc/DESI_ROOT/survey/fiberassign/SURVEY/TILEXX/TILEID-targ.rst
@@ -91,13 +91,13 @@ MASKBITS              int16                 Bitwise mask from the imaging indica
 SHAPE_R               float32  arcsec       Half-light radius of galaxy model (&gt;0)
 SHAPE_E1              float32               Ellipticity component 1 of galaxy model for galaxy type MORPHTYPE
 SHAPE_E2              float32               Ellipticity component 2 of galaxy model for galaxy type MORPHTYPE
-SERSIC                float32               Power-law index for the Sersic profile model (MORPHTYPE=&#x27;SER&#x27;)
+SERSIC                float32               Power-law index for the Sersic profile model (MORPHTYPE='SER')
 REF_ID                int64                 Tyc1*1,000,000+Tyc2*10+Tyc3 for Tycho-2; ``sourceid`` for Gaia DR2
-REF_CAT               char[2]               Reference catalog source for star: &#x27;T2&#x27; for Tycho-2, &#x27;G2&#x27; for Gaia DR2, &#x27;L2&#x27; for the SGA, empty otherwise
+REF_CAT               char[2]               Reference catalog source for star: 'T2' for Tycho-2, 'G2' for Gaia DR2, 'L2' for the SGA, empty otherwise
 GAIA_PHOT_G_MEAN_MAG  float32  mag          Gaia G band magnitude
 GAIA_PHOT_BP_MEAN_MAG float32  mag          Gaia BP band magnitude
 GAIA_PHOT_RP_MEAN_MAG float32  mag          Gaia RP band magnitude
-PHOTSYS               char[1]               &#x27;N&#x27; for the MzLS/BASS photometric system, &#x27;S&#x27; for DECaLS
+PHOTSYS               char[1]               'N' for the MzLS/BASS photometric system, 'S' for DECaLS
 TARGETID              int64                 Unique DESI target ID
 RA                    float64  deg          Barycentric Right Ascension in ICRS
 DEC                   float64  deg          Barycentric declination in ICRS
@@ -117,7 +117,7 @@ NUMOBS_MORE           int64                 Number of additional observations ne
 NUMOBS                int64                 Number of spectroscopic observations (on this specific, single tile)
 Z                     float64               Redshift measured by Redrock
 ZWARN                 int64                 Redshift warning bitmask from Redrock
-ZTILEID               int32                 ID of tile that most recently updated target&#x27;s state
+ZTILEID               int32                 ID of tile that most recently updated target's state
 Z_QN                  float64               Redshift measured by QuasarNET using line with highest confidence
 IS_QSO_QN             int16                 Spectroscopic classification from QuasarNET (1 for a quasar)
 DELTACHI2             float64               chi2 difference between first- and second-best redrock template fits

--- a/doc/DESI_ROOT/vac/RELEASE/lss/VERSION/LSScats/clustering/clustering_dat.rst
+++ b/doc/DESI_ROOT/vac/RELEASE/lss/VERSION/LSScats/clustering/clustering_dat.rst
@@ -64,7 +64,7 @@ RA                 float64  deg        Target Right Ascension
 DEC                float64  deg        Target declination
 TARGETID           int64               Unique DESI target ID
 NTILE              int64               Number of tiles target was available on
-TILES              char[*]             TILEIDs of those tile, in string form separated by &#x27;-&#x27;
+TILES              char[*]             TILEIDs of those tile, in string form separated by '-'
 Z                  float64             Redshift measured by Redrock
 COMP_TILE          float64             Assignment completeness for all targets of this type with the same value for TILES
 ROSETTE_NUMBER     int32               Rosette number ID [0-19]

--- a/doc/DESI_ROOT/vac/RELEASE/lss/VERSION/LSScats/clustering/clustering_ran.rst
+++ b/doc/DESI_ROOT/vac/RELEASE/lss/VERSION/LSScats/clustering/clustering_ran.rst
@@ -5,7 +5,7 @@ Clustering LSS catalogs for randoms
 :Summary: For each target type, LSS catalogs for the randoms, ready to be used for clustering measurements, are provided.
 :Naming Convention: ``{TARGET}_{PHOTSYS}_{RANN}_clustering.ran.fits``, where ``{TARGET}`` is the target type: ``QSO``, ``ELG``, ``ELGnotqso``, ``ELG_HIP``, ``ELG_HIPnotqso``, ``LRG``, ``LRG_main``,
                     for dark or ``BGS_ANY``, ``BGS_BRIGHT`` for bright. ``{PHOTSYS}`` is the photometric region ``N`` or ``S`` and ``{RANN}`` is the number for the random file (18 total, numbered 0 through 17). Each are random with respect to each other.
-:Regex: ``[a-zA-Z_]+\_[NS]_[0-9]+\_clustering.ran.fits`` 
+:Regex: ``[a-zA-Z_]+\_[NS]_[0-9]+\_clustering.ran.fits``
 :File Type: FITS, 193 MB
 
 Contents
@@ -63,7 +63,7 @@ RA                 float64  deg        Target Right Ascension
 DEC                float64  deg        Target declination
 TARGETID           int64               Unique DESI target ID
 NTILE              int64               Number of tiles target was available on
-TILES              char[*]             TILEIDs of those tile, in string form separated by &#x27;-&#x27;
+TILES              char[*]             TILEIDs of those tile, in string form separated by '-'
 Z                  float64             Redshift measured by Redrock
 COMP_TILE          float64             Assignment completeness for all targets of this type with the same value for TILES
 ROSETTE_NUMBER     int32               Rosette number ID [0-19]

--- a/doc/DESI_ROOT/vac/RELEASE/lss/VERSION/LSScats/full/fullVETO_dat.rst
+++ b/doc/DESI_ROOT/vac/RELEASE/lss/VERSION/LSScats/full/fullVETO_dat.rst
@@ -158,10 +158,10 @@ WISEMASK_W1                binary                   Bitwise mask for WISE W1 dat
 WISEMASK_W2                binary                   Bitwise mask for WISE W2 data
 MASKBITS                   int16                    Bitwise mask from the imaging indicating potential issue or blending
 SHAPE_R                    float32     arcsec       Half-light radius of galaxy model (&gt;0)
-PHOTSYS                    char[1]                  &#x27;N&#x27; for the MzLS/BASS photometric system, &#x27;S&#x27; for DECaLS
+PHOTSYS                    char[1]                  'N' for the MzLS/BASS photometric system, 'S' for DECaLS
 NTILE                      int64                    Number of tiles target was available on
-TILES                      char[51]                 TILEIDs of those tile, in string form separated by &#x27;-&#x27;
-TILELOCIDS                 char[151]                TILELOCIDs that the target was available for, separated by &#x27;-&#x27;
+TILES                      char[51]                 TILEIDs of those tile, in string form separated by '-'
+TILELOCIDS                 char[151]                TILELOCIDs that the target was available for, separated by '-'
 LOCATION_ASSIGNED          logical                  True/False for assigned/unassigned for the target in question
 TILELOCID_ASSIGNED         int64                    0/1 for unassigned/assigned for TILELOCID in question (it could have been assigned to a different target)
 GOODTSNR                   logical                  True/False whether the TSNR_&lt;class&gt; value used was above the minimum threshold for the given target class

--- a/doc/DESI_ROOT/vac/RELEASE/lss/VERSION/LSScats/full/fullVETO_ran.rst
+++ b/doc/DESI_ROOT/vac/RELEASE/lss/VERSION/LSScats/full/fullVETO_ran.rst
@@ -6,7 +6,7 @@ The 'full' LSS catalogs for randoms
 :Naming Convention: ``{TARGET}_{RANN}_full{VETO}.ran.fits``, where ``{TARGET}`` is the target type: ``QSO``, ``ELG``, ``ELGnotqso``, ``ELG_HIP``, ``ELG_HIPnotqso``, ``LRG``, ``LRG_main``,
                     for dark or ``BGS_ANY``, ``BGS_BRIGHT`` for bright. ``{RANN}`` is the number between 0 and 17 designating the given random file, and ``{VETO}`` is _noveto if vetos have not been applied and blank otherwise.
 :Regex: ``[a-zA-Z_]+\_[0-9]+\_full[a-z_]{0,7}.ran.fits``
-:File Type: FITS, 1 GB  
+:File Type: FITS, 1 GB
 
 
 Contents
@@ -104,8 +104,8 @@ TILELOCID                  int64                  Is 10000*TILEID+LOCATION
 GOODHARDLOC                logical                True/False whether the fiber had good hardware
 ZPOSSLOC                   logical                True/False whether the location could have been assigned to the given target class
 NTILE                      int64                  Number of tiles target was available on
-TILES                      char[51]               TILEIDs of those tile, in string form separated by &#x27;-&#x27;
-TILELOCIDS                 char[159]              TILELOCIDs that the target was available for, separated by &#x27;-&#x27;
+TILES                      char[51]               TILEIDs of those tile, in string form separated by '-'
+TILELOCIDS                 char[159]              TILELOCIDs that the target was available for, separated by '-'
 RELEASE                    int16                  Imaging surveys release ID
 BRICKID                    int32                  Brick ID from tractor input
 BRICKNAME                  char[8]                Brick name from tractor input
@@ -134,7 +134,7 @@ MASKBITS                   int16                  Bitwise mask from the imaging 
 WISEMASK_W1                binary                 Bitwise mask for WISE W1 data
 WISEMASK_W2                binary                 Bitwise mask for WISE W2 data
 EBV                        float32   mag          Galactic extinction E(B-V) reddening from SFD98
-PHOTSYS                    char[1]                &#x27;N&#x27; for the MzLS/BASS photometric system, &#x27;S&#x27; for DECaLS
+PHOTSYS                    char[1]                'N' for the MzLS/BASS photometric system, 'S' for DECaLS
 HPXPIXEL                   int64                  HEALPixel containing this location at NSIDE=64 in the NESTED scheme
 GOODPRI                    logical                True/False whether the priority of what was assigned to the location was &lt;= the base priority of the given target class
 GOODTSNR                   logical                True/False whether the TSNR_&lt;class&gt; value used was above the minimum threshold for the given target class

--- a/doc/DESI_ROOT/vac/RELEASE/lss/VERSION/inputs_wspec/data/Alltiles_tilelocs_dat.rst
+++ b/doc/DESI_ROOT/vac/RELEASE/lss/VERSION/inputs_wspec/data/Alltiles_tilelocs_dat.rst
@@ -2,9 +2,9 @@
 Alltiles_tilelocs
 ========================
 
-:Summary: Information on the tiles and locations each target appears on. 
+:Summary: Information on the tiles and locations each target appears on.
 :Naming Convention: ``Alltiles_{PROGRAM}_tilelocs.dat.fits``, where ``{PROGRAM}`` denotes the observing program, either ``dark`` or ``bright``.
-:Regex: ``Alltiles_[a-z]{4,6}_tilelocs.dat.fits`` 
+:Regex: ``Alltiles_[a-z]{4,6}_tilelocs.dat.fits``
 :File Type: FITS, 544 MB
 
 Contents
@@ -35,7 +35,7 @@ HDU1
 
 EXTNAME = TLINFO
 
-Information on the tiles and locations each target appears on 
+Information on the tiles and locations each target appears on
 
 Required Header Keywords
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -62,8 +62,8 @@ Name       Type      Units Description
 ========== ========= ===== ========================================================================
 TARGETID   int64           Unique DESI target ID
 NTILE      int64           Number of tiles target was available on
-TILES      char[*]         TILEIDs of those tile, in string form separated by &#x27;-&#x27;
-TILELOCIDS char[*]         TILELOCIDs that the target was available for, separated by &#x27;-&#x27;
+TILES      char[*]         TILEIDs of those tile, in string form separated by '-'
+TILELOCIDS char[*]         TILELOCIDs that the target was available for, separated by '-'
 ========== ========= ===== ========================================================================
 
 

--- a/doc/DESI_ROOT/vac/RELEASE/lss/VERSION/inputs_wspec/data/datcomb_tarspecwdup.rst
+++ b/doc/DESI_ROOT/vac/RELEASE/lss/VERSION/inputs_wspec/data/datcomb_tarspecwdup.rst
@@ -4,7 +4,7 @@ datcomb_tarspecwdup_Alltiles
 
 :Summary: Match of targets (with duplicates after FA) with spectroscopic data from the specprod (fuji/guadalupe for SV3/DA02).
 :Naming Convention: ``datcomb_{PROGRAM}_tarspecwdup_Alltiles.fits``, where ``{PROGRAM}`` denotes the observing program, either ``dark`` or ``bright``.
-:Regex: ``datcomb_[a-z]{4,6}_tarspecwdup_Alltiles.fits`` 
+:Regex: ``datcomb_[a-z]{4,6}_tarspecwdup_Alltiles.fits``
 :File Type: FITS, 2 GB
 
 Contents
@@ -71,7 +71,7 @@ NUMOBS_INIT [1]_           int64                 Initial number of observations 
 NUMOBS_MORE [1]_           int64                 Number of additional observations needed
 NUMOBS [1]_                int64                 Number of spectroscopic observations (on this specific, single tile)
 ZWARN_MTL                  int64                 The ZWARN from the zmtl file (contains extra bits)
-ZTILEID [1]_               int32                 ID of tile that most recently updated target&#x27;s state
+ZTILEID [1]_               int32                 ID of tile that most recently updated target's state
 TARGET_STATE               char[30]              Combination of target class and its current observational state
 TIMESTAMP                  char[25]    s         UTC/ISO time at which the target state was updated
 VERSION [1]_               char[14]              Tag of desitarget used to create the target catalog

--- a/doc/DESI_ROOT/vac/RELEASE/lss/VERSION/inputs_wspec/random/rancomb_Alltilelocinfo.rst
+++ b/doc/DESI_ROOT/vac/RELEASE/lss/VERSION/inputs_wspec/random/rancomb_Alltilelocinfo.rst
@@ -2,10 +2,10 @@
 rancomb_Alltilelocinfo
 ======================
 
-:Summary: For a random associated with ``{RANN}``, the list of unique TARGETIDs with number of appearances as reachable according to fiber assigment and details on those appearances. 
+:Summary: For a random associated with ``{RANN}``, the list of unique TARGETIDs with number of appearances as reachable according to fiber assigment and details on those appearances.
 :Naming Convention: ``rancomb_{RANN}{PROGRAM}_Alltilelocinfo.fits``, where ``{RANN}`` is the number of the random file (0 through 17) and ``{PROGRAM}`` is the observing program, either ``dark`` or ``bright``.
-:Regex: ``rancomb_[0-9]+(dark|bright)_Alltilelocinfo.fits`` 
-:File Type: FITS, 327 MB 
+:Regex: ``rancomb_[0-9]+(dark|bright)_Alltilelocinfo.fits``
+:File Type: FITS, 327 MB
 
 Contents
 ========
@@ -45,7 +45,7 @@ Required Header Keywords
     ====== ============= ==== =======================
     KEY    Example Value Type Comment
     ====== ============= ==== =======================
-    NAXIS1 66            int  width of table in bytes 
+    NAXIS1 66            int  width of table in bytes
     NAXIS2 5196355       int  number of rows in table
     DESIDR edr           str  DESI Data Release
     ====== ============= ==== =======================
@@ -60,7 +60,7 @@ Name       Type     Units Description
 ========== ======== ===== ========================================================================
 TARGETID   int64          Unique DESI target ID
 NTILE      int64          Number of tiles target was available on
-TILES      char[*]        TILEIDs of those tile, in string form separated by &#x27;-&#x27;
-TILELOCIDS char[*]        TILELOCIDs that the target was available for, separated by &#x27;-&#x27;
+TILES      char[*]        TILEIDs of those tile, in string form separated by '-'
+TILELOCIDS char[*]        TILELOCIDs that the target was available for, separated by '-'
 ========== ======== ===== ========================================================================
 

--- a/doc/DESI_ROOT/vac/RELEASE/lss/VERSION/potential_assignments/random/RANN/rancomb_Alltilelocinfo.rst
+++ b/doc/DESI_ROOT/vac/RELEASE/lss/VERSION/potential_assignments/random/RANN/rancomb_Alltilelocinfo.rst
@@ -60,7 +60,7 @@ Name       Type      Units Description
 ========== ========= ===== ========================================================================
 TARGETID   int64           Unique DESI target ID
 NTILE      int64           Number of tiles target was available on
-TILES      char[51]        TILEIDs of those tile, in string form separated by &#x27;-&#x27;
-TILELOCIDS char[159]       TILELOCIDs that the target was available for, separated by &#x27;-&#x27;
+TILES      char[51]        TILEIDs of those tile, in string form separated by '-'
+TILELOCIDS char[159]       TILELOCIDs that the target was available for, separated by '-'
 ========== ========= ===== ========================================================================
 

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/calibnight/NIGHT/psfnight-CAMERA-NIGHT.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/calibnight/NIGHT/psfnight-CAMERA-NIGHT.rst
@@ -142,7 +142,7 @@ Required Header Keywords
     PSFVER        3                                                           str
     MJD           0                                                           int   MJD of arc lamp exposure
     PLATEID       0                                                           int   plate ID of arc lamp exposure
-    CAMERA        &#x27;r9      &#x27;                                        str   camera ID
+    CAMERA        r9                                                          str   camera ID
     ARCEXP        0                                                           int   ID of arc lamp exposure used to fit PSF
     NPIX_X        4114                                                        int   number of columns in input CCD image
     NPIX_Y        4128                                                        int   number of rows in input CCD image

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/cframe-CAMERA-EXPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/cframe-CAMERA-EXPID.rst
@@ -1396,7 +1396,7 @@ SERSIC                float32              Power-law index for the Sersic profil
 SHAPE_R               float32 arcsec       Half-light radius of galaxy model (&gt;0)
 SHAPE_E1              float32              Ellipticity component 1 of galaxy model for galaxy type MORPHTYPE
 SHAPE_E2              float32              Ellipticity component 2 of galaxy model for galaxy type MORPHTYPE
-PHOTSYS               char[1]              &#x27;N&#x27; for the MzLS/BASS photometric system, &#x27;S&#x27; for DECaLS
+PHOTSYS               char[1]              'N' for the MzLS/BASS photometric system, 'S' for DECaLS
 PRIORITY_INIT         int64                Target initial priority from target selection bitmasks and OBSCONDITIONS
 NUMOBS_INIT           int64                Initial number of observations for target calculated across target selection bitmasks and OBSCONDITIONS
 SV1_DESI_TARGET [1]_  int64                DESI (dark time program) target selection bitmask for SV1

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/fiberflat-CAMERA-EXPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/fiberflat-CAMERA-EXPID.rst
@@ -994,17 +994,17 @@ FIBERTOTFLUX_G        float32 nanomaggy    Predicted g-band flux within a fiber 
 FIBERTOTFLUX_R        float32 nanomaggy    Predicted r-band flux within a fiber of diameter 1.5 arcsec from all sources at this location in 1 arcsec Gaussian seeing
 FIBERTOTFLUX_Z        float32 nanomaggy    Predicted z-band flux within a fiber of diameter 1.5 arcsec from all sources at this location in 1 arcsec Gaussian seeing
 MASKBITS              int16                Bitwise mask from the imaging indicating potential issue or blending
-SERSIC                float32              Power-law index for the Sersic profile model (MORPHTYPE=&#x27;SER&#x27;)
+SERSIC                float32              Power-law index for the Sersic profile model (MORPHTYPE='SER')
 SHAPE_R               float32 arcsec       Half-light radius of galaxy model (&gt;0)
 SHAPE_E1              float32              Ellipticity component 1 of galaxy model for galaxy type MORPHTYPE
 SHAPE_E2              float32              Ellipticity component 2 of galaxy model for galaxy type MORPHTYPE
 REF_ID                int64                Tyc1*1,000,000+Tyc2*10+Tyc3 for Tycho-2; ``sourceid`` for Gaia DR2
-REF_CAT               char[2]              Reference catalog source for star: &#x27;T2&#x27; for Tycho-2, &#x27;G2&#x27; for Gaia DR2, &#x27;L2&#x27; for the SGA, empty otherwise
+REF_CAT               char[2]              Reference catalog source for star: 'T2' for Tycho-2, 'G2' for Gaia DR2, 'L2' for the SGA, empty otherwise
 GAIA_PHOT_G_MEAN_MAG  float32 mag          Gaia G band magnitude
 GAIA_PHOT_BP_MEAN_MAG float32 mag          Gaia BP band magnitude
 GAIA_PHOT_RP_MEAN_MAG float32 mag          Gaia RP band magnitude
 PARALLAX              float32 mas          Reference catalog parallax
-PHOTSYS               char[1]              &#x27;N&#x27; for the MzLS/BASS photometric system, &#x27;S&#x27; for DECaLS
+PHOTSYS               char[1]              'N' for the MzLS/BASS photometric system, 'S' for DECaLS
 PRIORITY_INIT         int64                Target initial priority from target selection bitmasks and OBSCONDITIONS
 NUMOBS_INIT           int64                Initial number of observations for target calculated across target selection bitmasks and OBSCONDITIONS
 DESI_TARGET           int64                DESI (dark time program) target selection bitmask

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/fiberflatexp-CAMERA-EXPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/fiberflatexp-CAMERA-EXPID.rst
@@ -620,17 +620,17 @@ FIBERTOTFLUX_G             float32 nanomaggy    Predicted g-band flux within a f
 FIBERTOTFLUX_R             float32 nanomaggy    Predicted r-band flux within a fiber of diameter 1.5 arcsec from all sources at this location in 1 arcsec Gaussian seeing
 FIBERTOTFLUX_Z             float32 nanomaggy    Predicted z-band flux within a fiber of diameter 1.5 arcsec from all sources at this location in 1 arcsec Gaussian seeing
 MASKBITS [1]_              int16                Bitwise mask from the imaging indicating potential issue or blending
-SERSIC [1]_                float32              Power-law index for the Sersic profile model (MORPHTYPE=&#x27;SER&#x27;)
+SERSIC [1]_                float32              Power-law index for the Sersic profile model (MORPHTYPE='SER')
 SHAPE_R [1]_               float32 arcsec       Half-light radius of galaxy model (&gt;0)
 SHAPE_E1 [1]_              float32              Ellipticity component 1 of galaxy model for galaxy type MORPHTYPE
 SHAPE_E2 [1]_              float32              Ellipticity component 2 of galaxy model for galaxy type MORPHTYPE
 REF_ID                     int64                Tyc1*1,000,000+Tyc2*10+Tyc3 for Tycho-2; ``sourceid`` for Gaia DR2
-REF_CAT [1]_               char[2]              Reference catalog source for star: &#x27;T2&#x27; for Tycho-2, &#x27;G2&#x27; for Gaia DR2, &#x27;L2&#x27; for the SGA, empty otherwise
+REF_CAT [1]_               char[2]              Reference catalog source for star: 'T2' for Tycho-2, 'G2' for Gaia DR2, 'L2' for the SGA, empty otherwise
 GAIA_PHOT_G_MEAN_MAG [1]_  float32 mag          Gaia G band magnitude
 GAIA_PHOT_BP_MEAN_MAG [1]_ float32 mag          Gaia BP band magnitude
 GAIA_PHOT_RP_MEAN_MAG [1]_ float32 mag          Gaia RP band magnitude
 PARALLAX [1]_              float32 mas          Reference catalog parallax
-PHOTSYS                    char[1]              &#x27;N&#x27; for the MzLS/BASS photometric system, &#x27;S&#x27; for DECaLS
+PHOTSYS                    char[1]              'N' for the MzLS/BASS photometric system, 'S' for DECaLS
 PRIORITY_INIT              int64                Target initial priority from target selection bitmasks and OBSCONDITIONS
 NUMOBS_INIT                int64                Initial number of observations for target calculated across target selection bitmasks and OBSCONDITIONS
 DESI_TARGET                int64                DESI (dark time program) target selection bitmask

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/fluxcalib-CAMERA-EXPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/fluxcalib-CAMERA-EXPID.rst
@@ -1404,17 +1404,17 @@ FIBERTOTFLUX_G [1]_        float32 nanomaggy    Predicted g-band flux within a f
 FIBERTOTFLUX_R [1]_        float32 nanomaggy    Predicted r-band flux within a fiber of diameter 1.5 arcsec from all sources at this location in 1 arcsec Gaussian seeing
 FIBERTOTFLUX_Z [1]_        float32 nanomaggy    Predicted z-band flux within a fiber of diameter 1.5 arcsec from all sources at this location in 1 arcsec Gaussian seeing
 MASKBITS [1]_              int16                Bitwise mask from the imaging indicating potential issue or blending
-SERSIC [1]_                float32              Power-law index for the Sersic profile model (MORPHTYPE=&#x27;SER&#x27;)
+SERSIC [1]_                float32              Power-law index for the Sersic profile model (MORPHTYPE='SER')
 SHAPE_R [1]_               float32 arcsec       Half-light radius of galaxy model (&gt;0)
 SHAPE_E1 [1]_              float32              Ellipticity component 1 of galaxy model for galaxy type MORPHTYPE
 SHAPE_E2 [1]_              float32              Ellipticity component 2 of galaxy model for galaxy type MORPHTYPE
 REF_ID [1]_                int64                Tyc1*1,000,000+Tyc2*10+Tyc3 for Tycho-2; ``sourceid`` for Gaia DR2
-REF_CAT [1]_               char[2]              Reference catalog source for star: &#x27;T2&#x27; for Tycho-2, &#x27;G2&#x27; for Gaia DR2, &#x27;L2&#x27; for the SGA, empty otherwise
+REF_CAT [1]_               char[2]              Reference catalog source for star: 'T2' for Tycho-2, 'G2' for Gaia DR2, 'L2' for the SGA, empty otherwise
 GAIA_PHOT_G_MEAN_MAG [1]_  float32 mag          Gaia G band magnitude
 GAIA_PHOT_BP_MEAN_MAG [1]_ float32 mag          Gaia BP band magnitude
 GAIA_PHOT_RP_MEAN_MAG [1]_ float32 mag          Gaia RP band magnitude
 PARALLAX [1]_              float32 mas          Reference catalog parallax
-PHOTSYS [1]_               char[1]              &#x27;N&#x27; for the MzLS/BASS photometric system, &#x27;S&#x27; for DECaLS
+PHOTSYS [1]_               char[1]              'N' for the MzLS/BASS photometric system, 'S' for DECaLS
 PRIORITY_INIT [1]_         int64                Target initial priority from target selection bitmasks and OBSCONDITIONS
 NUMOBS_INIT [1]_           int64                Initial number of observations for target calculated across target selection bitmasks and OBSCONDITIONS
 DESI_TARGET [1]_           int64                DESI (dark time program) target selection bitmask

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/frame-CAMERA-EXPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/frame-CAMERA-EXPID.rst
@@ -1422,7 +1422,7 @@ SERSIC                float32              Power-law index for the Sersic profil
 SHAPE_R               float32 arcsec       Half-light radius of galaxy model (&gt;0)
 SHAPE_E1              float32              Ellipticity component 1 of galaxy model for galaxy type MORPHTYPE
 SHAPE_E2              float32              Ellipticity component 2 of galaxy model for galaxy type MORPHTYPE
-PHOTSYS               char[1]              &#x27;N&#x27; for the MzLS/BASS photometric system, &#x27;S&#x27; for DECaLS
+PHOTSYS               char[1]              'N' for the MzLS/BASS photometric system, 'S' for DECaLS
 PRIORITY_INIT         int64                Target initial priority from target selection bitmasks and OBSCONDITIONS
 NUMOBS_INIT           int64                Initial number of observations for target calculated across target selection bitmasks and OBSCONDITIONS
 CMX_TARGET [1]_       int64                Target selection bitmask for commissioning

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/sframe-CAMERA-EXPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/sframe-CAMERA-EXPID.rst
@@ -1386,7 +1386,7 @@ SERSIC                float32              Power-law index for the Sersic profil
 SHAPE_R               float32 arcsec       Half-light radius of galaxy model (&gt;0)
 SHAPE_E1              float32              Ellipticity component 1 of galaxy model for galaxy type MORPHTYPE
 SHAPE_E2              float32              Ellipticity component 2 of galaxy model for galaxy type MORPHTYPE
-PHOTSYS               char[1]              &#x27;N&#x27; for the MzLS/BASS photometric system, &#x27;S&#x27; for DECaLS
+PHOTSYS               char[1]              'N' for the MzLS/BASS photometric system, 'S' for DECaLS
 PRIORITY_INIT         int64                Target initial priority from target selection bitmasks and OBSCONDITIONS
 NUMOBS_INIT           int64                Initial number of observations for target calculated across target selection bitmasks and OBSCONDITIONS
 SV1_DESI_TARGET [1]_  int64                DESI (dark time program) target selection bitmask for SV1

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/stdstars-SPECTROGRAPH-EXPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/exposures/NIGHT/EXPID/stdstars-SPECTROGRAPH-EXPID.rst
@@ -833,7 +833,7 @@ FLUX_IVAR_R           float32 nanomaggy^-2 Inverse variance of FLUX_R (AB)
 FLUX_IVAR_Z           float32 nanomaggy^-2 Inverse variance of FLUX_Z (AB)
 MASKBITS              int16                Bitwise mask from the imaging indicating potential issue or blending
 REF_ID                int64                Tyc1*1,000,000+Tyc2*10+Tyc3 for Tycho-2; ``sourceid`` for Gaia DR2
-REF_CAT               char[2]              Reference catalog source for star: &#x27;T2&#x27; for Tycho-2, &#x27;G2&#x27; for Gaia DR2, &#x27;L2&#x27; for the SGA, empty otherwise
+REF_CAT               char[2]              Reference catalog source for star: 'T2' for Tycho-2, 'G2' for Gaia DR2, 'L2' for the SGA, empty otherwise
 GAIA_PHOT_G_MEAN_MAG  float32 mag          Gaia G band magnitude
 GAIA_PHOT_BP_MEAN_MAG float32 mag          Gaia BP band magnitude
 GAIA_PHOT_RP_MEAN_MAG float32 mag          Gaia RP band magnitude
@@ -850,11 +850,11 @@ FIBERFLUX_Z           float32 nanomaggy    Predicted z-band flux within a fiber 
 FIBERTOTFLUX_G        float32 nanomaggy    Predicted g-band flux within a fiber of diameter 1.5 arcsec from all sources at this location in 1 arcsec Gaussian seeing
 FIBERTOTFLUX_R        float32 nanomaggy    Predicted r-band flux within a fiber of diameter 1.5 arcsec from all sources at this location in 1 arcsec Gaussian seeing
 FIBERTOTFLUX_Z        float32 nanomaggy    Predicted z-band flux within a fiber of diameter 1.5 arcsec from all sources at this location in 1 arcsec Gaussian seeing
-SERSIC                float32              Power-law index for the Sersic profile model (MORPHTYPE=&#x27;SER&#x27;)
+SERSIC                float32              Power-law index for the Sersic profile model (MORPHTYPE='SER')
 SHAPE_R               float32 arcsec       Half-light radius of galaxy model (&gt;0)
 SHAPE_E1              float32              Ellipticity component 1 of galaxy model for galaxy type MORPHTYPE
 SHAPE_E2              float32              Ellipticity component 2 of galaxy model for galaxy type MORPHTYPE
-PHOTSYS               char[1]              &#x27;N&#x27; for the MzLS/BASS photometric system, &#x27;S&#x27; for DECaLS
+PHOTSYS               char[1]              'N' for the MzLS/BASS photometric system, 'S' for DECaLS
 PRIORITY_INIT         int64                Target initial priority from target selection bitmasks and OBSCONDITIONS
 NUMOBS_INIT           int64                Initial number of observations for target calculated across target selection bitmasks and OBSCONDITIONS
 SV1_DESI_TARGET [1]_  int64                DESI (dark time program) target selection bitmask for SV1

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/healpix/SURVEY/PROGRAM/PIXGROUP/PIXNUM/coadd-SURVEY-PROGRAM-PIXNUM.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/healpix/SURVEY/PROGRAM/PIXGROUP/PIXNUM/coadd-SURVEY-PROGRAM-PIXNUM.rst
@@ -66,7 +66,7 @@ Required Header Keywords
     KEY      Example Value               Type Comment
     ======== =========================== ==== ==============================================
     SPGRP    healpix                     str  Method of grouping spectra (always healpix for this file)
-    SPGRPVAL 38863                       int  Healpix number 
+    SPGRPVAL 38863                       int  Healpix number
     HPXPIXEL 38863                       int  Healpix number
     HPXNSIDE 64                          int  Healpix nside
     HPXNEST  True                        str  Healpix nested? (vs. ring)
@@ -164,7 +164,7 @@ SERSIC                     float32              Power-law index for the Sersic p
 SHAPE_R                    float32 arcsec       Half-light radius of galaxy model (&gt;0)
 SHAPE_E1                   float32              Ellipticity component 1 of galaxy model for galaxy type MORPHTYPE
 SHAPE_E2                   float32              Ellipticity component 2 of galaxy model for galaxy type MORPHTYPE
-PHOTSYS                    char[1]              &#x27;N&#x27; for the MzLS/BASS photometric system, &#x27;S&#x27; for DECaLS
+PHOTSYS                    char[1]              'N' for the MzLS/BASS photometric system, 'S' for DECaLS
 PRIORITY_INIT              int64                Target initial priority from target selection bitmasks and OBSCONDITIONS
 NUMOBS_INIT                int64                Initial number of observations for target calculated across target selection bitmasks and OBSCONDITIONS
 SV1_DESI_TARGET [1]_       int64                DESI (dark time program) target selection bitmask for SV1

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/healpix/SURVEY/PROGRAM/PIXGROUP/PIXNUM/redrock-SURVEY-PROGRAM-PIXNUM.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/healpix/SURVEY/PROGRAM/PIXGROUP/PIXNUM/redrock-SURVEY-PROGRAM-PIXNUM.rst
@@ -195,7 +195,7 @@ SERSIC                     float32              Power-law index for the Sersic p
 SHAPE_R                    float32 arcsec       Half-light radius of galaxy model (&gt;0)
 SHAPE_E1                   float32              Ellipticity component 1 of galaxy model for galaxy type MORPHTYPE
 SHAPE_E2                   float32              Ellipticity component 2 of galaxy model for galaxy type MORPHTYPE
-PHOTSYS                    char[1]              &#x27;N&#x27; for the MzLS/BASS photometric system, &#x27;S&#x27; for DECaLS
+PHOTSYS                    char[1]              'N' for the MzLS/BASS photometric system, 'S' for DECaLS
 PRIORITY_INIT              int64                Target initial priority from target selection bitmasks and OBSCONDITIONS
 NUMOBS_INIT                int64                Initial number of observations for target calculated across target selection bitmasks and OBSCONDITIONS
 DESI_TARGET                int64                DESI (dark time program) target selection bitmask

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/healpix/SURVEY/PROGRAM/PIXGROUP/PIXNUM/spectra-SURVEY-PROGRAM-PIXNUM.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/healpix/SURVEY/PROGRAM/PIXGROUP/PIXNUM/spectra-SURVEY-PROGRAM-PIXNUM.rst
@@ -188,7 +188,7 @@ SERSIC                float32              Power-law index for the Sersic profil
 SHAPE_R               float32 arcsec       Half-light radius of galaxy model (&gt;0)
 SHAPE_E1              float32              Ellipticity component 1 of galaxy model for galaxy type MORPHTYPE
 SHAPE_E2              float32              Ellipticity component 2 of galaxy model for galaxy type MORPHTYPE
-PHOTSYS               char[1]              &#x27;N&#x27; for the MzLS/BASS photometric system, &#x27;S&#x27; for DECaLS
+PHOTSYS               char[1]              'N' for the MzLS/BASS photometric system, 'S' for DECaLS
 PRIORITY_INIT         int64                Target initial priority from target selection bitmasks and OBSCONDITIONS
 NUMOBS_INIT           int64                Initial number of observations for target calculated across target selection bitmasks and OBSCONDITIONS
 SV1_DESI_TARGET [1]_  int64                DESI (dark time program) target selection bitmask for SV1

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/preproc/NIGHT/EXPID/fibermap-EXPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/preproc/NIGHT/EXPID/fibermap-EXPID.rst
@@ -572,7 +572,7 @@ GAIA_PHOT_G_MEAN_MAG  float32 mag          Gaia G band magnitude
 GAIA_PHOT_BP_MEAN_MAG float32 mag          Gaia BP band magnitude
 GAIA_PHOT_RP_MEAN_MAG float32 mag          Gaia RP band magnitude
 PARALLAX              float32 mas          Reference catalog parallax
-PHOTSYS               char[1]              &#x27;N&#x27; for the MzLS/BASS photometric system, &#x27;S&#x27; for DECaLS
+PHOTSYS               char[1]              'N' for the MzLS/BASS photometric system, 'S' for DECaLS
 PRIORITY_INIT         int64                Target initial priority from target selection bitmasks and OBSCONDITIONS
 NUMOBS_INIT           int64                Initial number of observations for target calculated across target selection bitmasks and OBSCONDITIONS
 SV1_DESI_TARGET [1]_  int64                DESI (dark time program) target selection bitmask for SV1

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/preproc/NIGHT/EXPID/preproc-CAMERA-EXPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/preproc/NIGHT/EXPID/preproc-CAMERA-EXPID.rst
@@ -1344,17 +1344,17 @@ FIBERTOTFLUX_G        float32 nanomaggies        Predicted g-band flux within a 
 FIBERTOTFLUX_R        float32 nanomaggies        Predicted r-band flux within a fiber of diameter 1.5 arcsec from all sources at this location in 1 arcsec Gaussian seeing
 FIBERTOTFLUX_Z        float32 nanomaggies        Predicted z-band flux within a fiber of diameter 1.5 arcsec from all sources at this location in 1 arcsec Gaussian seeing
 MASKBITS              int16                      Bitwise mask from the imaging indicating potential issue or blending
-SERSIC                float32                    Power-law index for the Sersic profile model (MORPHTYPE=&#x27;SER&#x27;)
+SERSIC                float32                    Power-law index for the Sersic profile model (MORPHTYPE='SER')
 SHAPE_R               float32 arcsec             Half-light radius of galaxy model (&gt;0)
 SHAPE_E1              float32                    Ellipticity component 1 of galaxy model for galaxy type MORPHTYPE
 SHAPE_E2              float32                    Ellipticity component 2 of galaxy model for galaxy type MORPHTYPE
 REF_ID                int64                      Tyc1*1,000,000+Tyc2*10+Tyc3 for Tycho-2; ``sourceid`` for Gaia DR2
-REF_CAT               char[2]                    Reference catalog source for star: &#x27;T2&#x27; for Tycho-2, &#x27;G2&#x27; for Gaia DR2, &#x27;L2&#x27; for the SGA, empty otherwise
+REF_CAT               char[2]                    Reference catalog source for star: 'T2' for Tycho-2, 'G2' for Gaia DR2, 'L2' for the SGA, empty otherwise
 GAIA_PHOT_G_MEAN_MAG  float32 mag                Gaia G band magnitude
 GAIA_PHOT_BP_MEAN_MAG float32 mag                Gaia BP band magnitude
 GAIA_PHOT_RP_MEAN_MAG float32 mag                Gaia RP band magnitude
 PARALLAX              float32 10**-3 arcsec      Reference catalog parallax
-PHOTSYS               char[1]                    &#x27;N&#x27; for the MzLS/BASS photometric system, &#x27;S&#x27; for DECaLS
+PHOTSYS               char[1]                    'N' for the MzLS/BASS photometric system, 'S' for DECaLS
 PRIORITY_INIT         int64                      Target initial priority from target selection bitmasks and OBSCONDITIONS
 NUMOBS_INIT           int64                      Initial number of observations for target calculated across target selection bitmasks and OBSCONDITIONS
 DESI_TARGET           int64                      DESI (dark time program) target selection bitmask

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/preproc/NIGHT/EXPID/preproc-CAMERA-EXPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/preproc/NIGHT/EXPID/preproc-CAMERA-EXPID.rst
@@ -1332,11 +1332,11 @@ FLUX_R                float32 nanomaggies        Flux in the Legacy Survey r-ban
 FLUX_Z                float32 nanomaggies        Flux in the Legacy Survey z-band (AB)
 FLUX_W1               float32 nanomaggies        WISE flux in W1 (AB)
 FLUX_W2               float32 nanomaggies        WISE flux in W2 (AB)
-FLUX_IVAR_G           float32 1/nanomaggies**2   Inverse variance of FLUX_G (AB)
-FLUX_IVAR_R           float32 1/nanomaggies**2   Inverse variance of FLUX_R (AB)
-FLUX_IVAR_Z           float32 1/nanomaggies**2   Inverse variance of FLUX_Z (AB)
-FLUX_IVAR_W1          float32 1/nanomaggies**2   Inverse variance of FLUX_W1 (AB)
-FLUX_IVAR_W2          float32 1/nanomaggies**2   Inverse variance of FLUX_W2 (AB)
+FLUX_IVAR_G           float32 nanomaggies**-2    Inverse variance of FLUX_G (AB)
+FLUX_IVAR_R           float32 nanomaggies**-2    Inverse variance of FLUX_R (AB)
+FLUX_IVAR_Z           float32 nanomaggies**-2    Inverse variance of FLUX_Z (AB)
+FLUX_IVAR_W1          float32 nanomaggies**-2    Inverse variance of FLUX_W1 (AB)
+FLUX_IVAR_W2          float32 nanomaggies**-2    Inverse variance of FLUX_W2 (AB)
 FIBERFLUX_G           float32 nanomaggies        Predicted g-band flux within a fiber of diameter 1.5 arcsec from this object in 1 arcsec Gaussian seeing
 FIBERFLUX_R           float32 nanomaggies        Predicted r-band flux within a fiber of diameter 1.5 arcsec from this object in 1 arcsec Gaussian seeing
 FIBERFLUX_Z           float32 nanomaggies        Predicted z-band flux within a fiber of diameter 1.5 arcsec from this object in 1 arcsec Gaussian seeing

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/tiles/GROUPTYPE/TILEID/GROUPID/coadd-SPECTROGRAPH-TILEID-GROUPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/tiles/GROUPTYPE/TILEID/GROUPID/coadd-SPECTROGRAPH-TILEID-GROUPID.rst
@@ -180,7 +180,7 @@ SERSIC                     float32              Power-law index for the Sersic p
 SHAPE_R                    float32 arcsec       Half-light radius of galaxy model (&gt;0)
 SHAPE_E1                   float32              Ellipticity component 1 of galaxy model for galaxy type MORPHTYPE
 SHAPE_E2                   float32              Ellipticity component 2 of galaxy model for galaxy type MORPHTYPE
-PHOTSYS                    char[1]              &#x27;N&#x27; for the MzLS/BASS photometric system, &#x27;S&#x27; for DECaLS
+PHOTSYS                    char[1]              'N' for the MzLS/BASS photometric system, 'S' for DECaLS
 PRIORITY_INIT              int64                Target initial priority from target selection bitmasks and OBSCONDITIONS
 NUMOBS_INIT                int64                Initial number of observations for target calculated across target selection bitmasks and OBSCONDITIONS
 SV1_DESI_TARGET [1]_       int64                DESI (dark time program) target selection bitmask for SV1

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/tiles/GROUPTYPE/TILEID/GROUPID/redrock-SPECTROGRAPH-TILEID-GROUPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/tiles/GROUPTYPE/TILEID/GROUPID/redrock-SPECTROGRAPH-TILEID-GROUPID.rst
@@ -202,7 +202,7 @@ GAIA_PHOT_G_MEAN_MAG       float32 mag          Gaia G band magnitude
 GAIA_PHOT_BP_MEAN_MAG      float32 mag          Gaia BP band magnitude
 GAIA_PHOT_RP_MEAN_MAG      float32 mag          Gaia RP band magnitude
 PARALLAX                   float32 mas          Reference catalog parallax
-PHOTSYS                    char[1]              &#x27;N&#x27; for the MzLS/BASS photometric system, &#x27;S&#x27; for DECaLS
+PHOTSYS                    char[1]              'N' for the MzLS/BASS photometric system, 'S' for DECaLS
 PRIORITY_INIT              int64                Target initial priority from target selection bitmasks and OBSCONDITIONS
 NUMOBS_INIT                int64                Initial number of observations for target calculated across target selection bitmasks and OBSCONDITIONS
 SV1_DESI_TARGET [1]_       int64                DESI (dark time program) target selection bitmask for SV1

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/tiles/GROUPTYPE/TILEID/GROUPID/spectra-SPECTROGRAPH-TILEID-GROUPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/tiles/GROUPTYPE/TILEID/GROUPID/spectra-SPECTROGRAPH-TILEID-GROUPID.rst
@@ -200,7 +200,7 @@ SERSIC                float32              Power-law index for the Sersic profil
 SHAPE_R               float32 arcsec       Half-light radius of galaxy model (&gt;0)
 SHAPE_E1              float32              Ellipticity component 1 of galaxy model for galaxy type MORPHTYPE
 SHAPE_E2              float32              Ellipticity component 2 of galaxy model for galaxy type MORPHTYPE
-PHOTSYS               char[1]              &#x27;N&#x27; for the MzLS/BASS photometric system, &#x27;S&#x27; for DECaLS
+PHOTSYS               char[1]              'N' for the MzLS/BASS photometric system, 'S' for DECaLS
 PRIORITY_INIT         int64                Target initial priority from target selection bitmasks and OBSCONDITIONS
 NUMOBS_INIT           int64                Initial number of observations for target calculated across target selection bitmasks and OBSCONDITIONS
 SV1_DESI_TARGET [1]_  int64                DESI (dark time program) target selection bitmask for SV1

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/tiles/GROUPTYPE/TILEID/GROUPID/zmtl-SPECTROGRAPH-TILEID-GROUPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/tiles/GROUPTYPE/TILEID/GROUPID/zmtl-SPECTROGRAPH-TILEID-GROUPID.rst
@@ -89,7 +89,7 @@ ZWARN                int64         Redshift warning bitmask from Redrock, plus D
 SPECTYPE             char[6]       Spectral type of Redrock best fit template (e.g. GALAXY, QSO, STAR)
 DELTACHI2            float64       chi2 difference between first- and second-best redrock template fits
 NUMOBS               int32         Number of spectroscopic observations (on this specific, single tile)
-ZTILEID              int32         ID of tile that most recently updated target&#x27;s state
+ZTILEID              int32         ID of tile that most recently updated target's state
 Z_QN                 float64       Redshift measured by QuasarNET
 Z_QN_CONF            float64       Redshift confidence from QuasarNET
 IS_QSO_QN            int16         Spectroscopic classification from QuasarNET (1 for a quasar)

--- a/doc/DESI_SPECTRO_SIM/PIXPROD/NIGHT/EXPID/simspec-EXPID.rst
+++ b/doc/DESI_SPECTRO_SIM/PIXPROD/NIGHT/EXPID/simspec-EXPID.rst
@@ -477,7 +477,7 @@ MW_TRANSMISSION_G float32                     Milky Way dust transmission in LS 
 MW_TRANSMISSION_R float32                     Milky Way dust transmission in LS r-band
 MW_TRANSMISSION_Z float32                     Milky Way dust transmission in LS z-band
 EBV               float32 mag                 Galactic extinction E(B-V) reddening from SFD98
-PHOTSYS           char[1]                     &#x27;N&#x27; for the MzLS/BASS photometric system, &#x27;S&#x27; for DECaLS
+PHOTSYS           char[1]                     'N' for the MzLS/BASS photometric system, 'S' for DECaLS
 OBSCONDITIONS     int32                       Bitmask of allowed observing conditions
 NUMOBS_INIT       int64                       Initial number of observations for target calculated across target selection bitmasks and OBSCONDITIONS
 PRIORITY_INIT     int64                       Target initial priority from target selection bitmasks and OBSCONDITIONS

--- a/doc/DESI_SPECTRO_SIM/PIXPROD/NIGHT/EXPID/simspec-EXPID.rst
+++ b/doc/DESI_SPECTRO_SIM/PIXPROD/NIGHT/EXPID/simspec-EXPID.rst
@@ -458,11 +458,11 @@ FLUX_R            float32 nanomaggy           Flux in the Legacy Survey r-band (
 FLUX_Z            float32 nanomaggy           Flux in the Legacy Survey z-band (AB)
 FLUX_W1           float32 nanomaggy           WISE flux in W1 (AB)
 FLUX_W2           float32 nanomaggy           WISE flux in W2 (AB)
-FLUX_IVAR_G       float32 1/nanomaggies**2    Inverse variance of FLUX_G (AB)
-FLUX_IVAR_R       float32 1/nanomaggies**2    Inverse variance of FLUX_R (AB)
-FLUX_IVAR_Z       float32 1/nanomaggies**2    Inverse variance of FLUX_Z (AB)
-FLUX_IVAR_W1      float32 1/nanomaggies**2    Inverse variance of FLUX_W1 (AB)
-FLUX_IVAR_W2      float32 1/nanomaggies**2    Inverse variance of FLUX_W2 (AB)
+FLUX_IVAR_G       float32 nanomaggies**-2     Inverse variance of FLUX_G (AB)
+FLUX_IVAR_R       float32 nanomaggies**-2     Inverse variance of FLUX_R (AB)
+FLUX_IVAR_Z       float32 nanomaggies**-2     Inverse variance of FLUX_Z (AB)
+FLUX_IVAR_W1      float32 nanomaggies**-2     Inverse variance of FLUX_W1 (AB)
+FLUX_IVAR_W2      float32 nanomaggies**-2     Inverse variance of FLUX_W2 (AB)
 FIBERFLUX_G       float32 nanomaggies         Predicted g-band flux within a fiber of diameter 1.5 arcsec from this object in 1 arcsec Gaussian seeing
 FIBERFLUX_R       float32 nanomaggies         Predicted r-band flux within a fiber of diameter 1.5 arcsec from this object in 1 arcsec Gaussian seeing
 FIBERFLUX_Z       float32 nanomaggies         Predicted z-band flux within a fiber of diameter 1.5 arcsec from this object in 1 arcsec Gaussian seeing

--- a/doc/DESI_TARGET/fiberassign/tiles/TILES_VERSION/TILEXX/uncompressed-fiberassign-TILEID.rst
+++ b/doc/DESI_TARGET/fiberassign/tiles/TILES_VERSION/TILEXX/uncompressed-fiberassign-TILEID.rst
@@ -268,7 +268,7 @@ FLUX_IVAR_G                       float32 nanomaggy^-2 Inverse variance of FLUX_
 FLUX_IVAR_R                       float32 nanomaggy^-2 Inverse variance of FLUX_R (AB)
 FLUX_IVAR_Z                       float32 nanomaggy^-2 Inverse variance of FLUX_Z (AB)
 REF_ID                            int64                Tyc1*1,000,000+Tyc2*10+Tyc3 for Tycho-2; ``sourceid`` for Gaia DR2
-REF_CAT                           char[2]              Reference catalog source for star: &#x27;T2&#x27; for Tycho-2, &#x27;G2&#x27; for Gaia DR2, &#x27;L2&#x27; for the SGA, empty otherwise
+REF_CAT                           char[2]              Reference catalog source for star: 'T2' for Tycho-2, 'G2' for Gaia DR2, 'L2' for the SGA, empty otherwise
 REF_EPOCH                         float32 yr           Reference epoch for Gaia/Tycho astrometry. Typically 2015.5 for Gaia
 PARALLAX                          float32 mas          Reference catalog parallax
 PARALLAX_IVAR                     float32 mas^-2       Inverse variance of PARALLAX

--- a/py/desidatamodel/check.py
+++ b/py/desidatamodel/check.py
@@ -507,7 +507,7 @@ class DataModel(object):
                     s = Stub(p, error=error)
                 except OSError as err:
                     log.warning("Error opening %s, skipping to next candidate.", p)
-                    log.warning("Message was: '%s'.", err)
+                    log.warning("Message was: '%s'.", err.args[0])
                 else:
                     log.debug("(s.nhdr = %s) == (len(modelmeta.keys()) = %s)",
                               s.nhdr, len(modelmeta.keys()))

--- a/py/desidatamodel/check.py
+++ b/py/desidatamodel/check.py
@@ -18,10 +18,10 @@ from desiutil.log import log, DEBUG
 
 from . import DataModelError
 from .stub import Stub
-from .unit import DataModelUnit
+from .unit import validate_unit
 
 
-class DataModel(DataModelUnit):
+class DataModel(object):
     """Simple object to store data model data and metadata.
 
     Parameters
@@ -397,7 +397,7 @@ class DataModel(DataModelUnit):
                         else:
                             log.warning(m, mk[0], k, metafile)
                     if mk[2]:
-                        bad_unit = self.check_unit(mk[2], error=error)
+                        bad_unit = validate_unit(mk[2], error=error)
                         if bad_unit:
                             log.debug("Non-standard (but acceptable) unit %s detected for column %s in HDU %d of %s.",
                                       bad_unit, mk[0], k, metafile)
@@ -421,7 +421,7 @@ class DataModel(DataModelUnit):
                         else:
                             log.warning(m, mk[0], k, metafile)
                     if mk[0] == 'BUNIT':
-                        bad_unit = self.check_unit(mk[1], error=error)
+                        bad_unit = validate_unit(mk[1], error=error)
                         if bad_unit:
                             log.debug("Non-standard (but acceptable) unit %s detected for column %s in HDU %d of %s.",
                                       bad_unit, mk[0], k, metafile)

--- a/py/desidatamodel/stub.py
+++ b/py/desidatamodel/stub.py
@@ -20,7 +20,7 @@ from astropy.table import Table
 from desiutil.log import log, DEBUG
 
 from . import DataModelError
-from .unit import DataModelUnit
+from .unit import validate_unit
 #
 # This is a template.
 #
@@ -56,7 +56,7 @@ Notes and Examples
 """
 
 
-class Stub(DataModelUnit):
+class Stub(object):
     """This object contains metadata about a file and methods to print that
     metadata.
 
@@ -280,7 +280,7 @@ class Stub(DataModelUnit):
             tunit = 'TUNIT'+jj
             if tunit in hdr:
                 units = hdr[tunit].strip()
-                bad_unit = self.check_unit(units, error=error)
+                bad_unit = validate_unit(units, error=error)
                 if bad_unit:
                     log.debug("Non-standard (but acceptable) unit %s detected for column %s in HDU %d of %s.",
                               bad_unit, j, hdu, self.filename)
@@ -305,7 +305,7 @@ class Stub(DataModelUnit):
                     log.warning('Overriding header units "%s" with units "%s" from %s',
                                 units, desc_units, self.description_file)
 
-                    bad_unit = self.check_unit(desc_units, error=error)
+                    bad_unit = validate_unit(desc_units, error=error)
                     if bad_unit:
                         log.debug('Non-standard (but acceptable) units "%s" detected for column %s in %s',
                                   bad_unit, name, self.description_file)
@@ -525,7 +525,7 @@ class Stub(DataModelUnit):
                 datatype = 'BITPIX={}'.format(hdr['BITPIX'])
         if 'BUNIT' in hdr:
             log.debug("BUNIT   = '%s'", hdr['BUNIT'])
-            bad_unit = self.check_unit(hdr['BUNIT'], error=self.error)
+            bad_unit = validate_unit(hdr['BUNIT'], error=self.error)
             if bad_unit:
                 log.debug("Non-standard (but acceptable) unit %s detected in %s.",
                           bad_unit, self.filename)

--- a/py/desidatamodel/test/test_check.py
+++ b/py/desidatamodel/test/test_check.py
@@ -5,15 +5,11 @@
 import os
 from packaging import version
 from unittest.mock import patch
-
-skip_unit_warning = False
 try:
     from desiutil.annotate import FITSUnitWarning
 except ImportError:
-    skip_unit_warning = True
-
+    from ..unit import FITSUnitWarning
 from .datamodeltestcase import DataModelTestCase, DM
-
 from .. import DataModelError
 from ..check import (DataModel, collect_files, files_to_regexp, scan_model,
                      validate_prototypes, log, _options)

--- a/py/desidatamodel/test/test_check.py
+++ b/py/desidatamodel/test/test_check.py
@@ -3,10 +3,14 @@
 """Test desidatamodel.check functions
 """
 import os
-import sys
 from packaging import version
-import unittest
 from unittest.mock import patch
+
+skip_unit_warning = False
+try:
+    from desiutil.annotate import FITSUnitWarning
+except ImportError:
+    skip_unit_warning = True
 
 from .datamodeltestcase import DataModelTestCase, DM
 
@@ -310,9 +314,10 @@ class TestCheck(DataModelTestCase):
             meta = model.extract_metadata(error=True)
         self.assertEqual(str(e.exception), erg_msg)
         model.hdumeta = None
-        meta = model.extract_metadata(error=False)
+        with self.assertWarns(FITSUnitWarning) as w:
+            meta = model.extract_metadata(error=False)
+        self.assertEqual(str(w.warning), erg_msg)
         self.assertLog(log, -1, "HDU 0 in {0} should have a more meaningful EXTNAME than 'PRIMARY'.".format(modelfile))
-        self.assertLog(log, -2, erg_msg)
 
     def test_extract_metadata_missing_keyword_unit(self):
         """Test reading metadata with missing units for header keywords.
@@ -347,8 +352,9 @@ class TestCheck(DataModelTestCase):
             meta = model.extract_metadata(error=True)
         self.assertEqual(str(e.exception), erg_msg)
         model.hdumeta = None
-        meta = model.extract_metadata(error=False)
-        self.assertLog(log, -1, erg_msg)
+        with self.assertWarns(FITSUnitWarning) as w:
+            meta = model.extract_metadata(error=False)
+        self.assertEqual(str(w.warning), erg_msg)
 
     def test_extract_metadata_missing_column_type(self):
         """Test reading metadata with missing FITS column types.

--- a/py/desidatamodel/test/test_model.py
+++ b/py/desidatamodel/test/test_model.py
@@ -3,7 +3,6 @@
 """Test data model files for validity.
 """
 import os
-import unittest
 
 from .datamodeltestcase import DataModelTestCase
 

--- a/py/desidatamodel/test/test_scan.py
+++ b/py/desidatamodel/test/test_scan.py
@@ -3,15 +3,12 @@
 """Test desidatamodel.scan functions
 """
 import os
-import unittest
 from unittest.mock import patch, call
-from pkg_resources import resource_filename
-from astropy.io import fits
-from astropy.io.fits.card import Undefined
-from collections import OrderedDict
+# from astropy.io import fits
+# from astropy.io.fits.card import Undefined
+# from collections import OrderedDict
 
 from .datamodeltestcase import DataModelTestCase, DM
-from .. import DataModelError
 from ..check import DataModel
 from ..stub import Stub
 from ..scan import _options, collect_files, union_metadata, UnionStub, log

--- a/py/desidatamodel/test/test_stub.py
+++ b/py/desidatamodel/test/test_stub.py
@@ -7,12 +7,10 @@ from unittest.mock import patch, call
 from astropy.io import fits
 from astropy.io.fits.card import Undefined
 from collections import OrderedDict
-
-skip_unit_warning = False
 try:
     from desiutil.annotate import FITSUnitWarning
 except ImportError:
-    skip_unit_warning = True
+    from ..unit import FITSUnitWarning
 from .datamodeltestcase import DataModelTestCase
 from .. import DataModelError
 from ..stub import (Stub, extrakey, file_size, fits_column_format,
@@ -326,8 +324,9 @@ class TestStub(DataModelTestCase):
         stub = Stub(hdulist, error=False)
         stub.filename = 'fits_file.fits'
         stub._filesize = '10 MB'
-        self.assertEqual(stub.hdumeta[1]['format'][2], ('luminosity', 'float32', 'ergs', 'This is a TCOMM comment on luminosity.'))
-        # self.assertLog(log, 1, erg_msg)
+        with self.assertWarns(FITSUnitWarning) as w:
+            self.assertEqual(stub.hdumeta[1]['format'][2], ('luminosity', 'float32', 'ergs', 'This is a TCOMM comment on luminosity.'))
+        self.assertEqual(str(w.warning), erg_msg)
         stub = Stub(hdulist, error=True)
         stub.filename = 'fits_file.fits'
         stub._filesize = '10 MB'

--- a/py/desidatamodel/test/test_unit.py
+++ b/py/desidatamodel/test/test_unit.py
@@ -5,7 +5,7 @@
 # import os
 import unittest
 from .datamodeltestcase import DataModelTestCase
-from ..unit import DataModelUnit, log
+from ..unit import validate_unit, log
 
 
 class TestUnit(DataModelTestCase):
@@ -16,15 +16,14 @@ class TestUnit(DataModelTestCase):
         """Test method to validate units.
         """
         erg_msg = self.badUnitMessage('ergs')
-        u = DataModelUnit()
-        c = u.check_unit('erg')
+        c = validate_unit('erg')
         self.assertIsNone(c)
-        c = u.check_unit('ergs', error=False)
+        c = validate_unit('ergs', error=False)
         self.assertIsNone(c)
-        c = u.check_unit('nanomaggies', error=True)
+        c = validate_unit('nanomaggies', error=True)
         self.assertEqual(c, "'nanomaggies'")
         self.assertLog(log, -1, erg_msg)
         with self.assertRaises(ValueError) as e:
-            c = u.check_unit('ergs', error=True)
+            c = validate_unit('ergs', error=True)
         self.assertEqual(str(e.exception), erg_msg)
         self.assertLog(log, -1, erg_msg)

--- a/py/desidatamodel/test/test_unit.py
+++ b/py/desidatamodel/test/test_unit.py
@@ -2,8 +2,11 @@
 # -*- coding: utf-8 -*-
 """Test desidatamodel.unit functions
 """
-# import os
-import unittest
+skip_unit_warning = False
+try:
+    from desiutil.annotate import FITSUnitWarning
+except ImportError:
+    skip_unit_warning = True
 from .datamodeltestcase import DataModelTestCase
 from ..unit import validate_unit, log
 
@@ -18,12 +21,12 @@ class TestUnit(DataModelTestCase):
         erg_msg = self.badUnitMessage('ergs')
         c = validate_unit('erg')
         self.assertIsNone(c)
-        c = validate_unit('ergs', error=False)
+        with self.assertWarns(FITSUnitWarning) as w:
+            c = validate_unit('ergs', error=False)
+        self.assertEqual(str(w.warning), erg_msg)
         self.assertIsNone(c)
         c = validate_unit('nanomaggies', error=True)
         self.assertEqual(c, "'nanomaggies'")
-        self.assertLog(log, -1, erg_msg)
         with self.assertRaises(ValueError) as e:
             c = validate_unit('ergs', error=True)
         self.assertEqual(str(e.exception), erg_msg)
-        self.assertLog(log, -1, erg_msg)

--- a/py/desidatamodel/test/test_unit.py
+++ b/py/desidatamodel/test/test_unit.py
@@ -2,20 +2,15 @@
 # -*- coding: utf-8 -*-
 """Test desidatamodel.unit functions
 """
-skip_unit_warning = False
-try:
-    from desiutil.annotate import FITSUnitWarning
-except ImportError:
-    skip_unit_warning = True
 from .datamodeltestcase import DataModelTestCase
-from ..unit import validate_unit, log
+from ..unit import validate_unit, _validate_unit, FITSUnitWarning
 
 
 class TestUnit(DataModelTestCase):
     """Test desidatamodel.unit functions
     """
 
-    def test_check_model(self):
+    def test_validate_unit(self):
         """Test method to validate units.
         """
         erg_msg = self.badUnitMessage('ergs')
@@ -29,4 +24,20 @@ class TestUnit(DataModelTestCase):
         self.assertEqual(c, "'nanomaggies'")
         with self.assertRaises(ValueError) as e:
             c = validate_unit('ergs', error=True)
+        self.assertEqual(str(e.exception), erg_msg)
+
+    def test_legacy_validate_unit(self):
+        """Test old method to validate units.
+        """
+        erg_msg = self.badUnitMessage('ergs')
+        c = _validate_unit('erg')
+        self.assertIsNone(c)
+        with self.assertWarns(FITSUnitWarning) as w:
+            c = _validate_unit('ergs', error=False)
+        self.assertEqual(str(w.warning), erg_msg)
+        self.assertIsNone(c)
+        c = _validate_unit('nanomaggies', error=True)
+        self.assertEqual(c, "'nanomaggies'")
+        with self.assertRaises(ValueError) as e:
+            c = _validate_unit('ergs', error=True)
         self.assertEqual(str(e.exception), erg_msg)

--- a/py/desidatamodel/unit.py
+++ b/py/desidatamodel/unit.py
@@ -11,47 +11,58 @@ from astropy.units import Unit
 from desiutil.log import log
 from . import DataModelError
 
+def _validate_unit(unit, error=False):
+    """Check units for consistency with FITS standard, while allowing
+    some special exceptions.
+
+    Parameters
+    ----------
+    unit : :class:`str`
+        The unit to parse.
+    error : :class:`bool`, optional
+        If ``True``, failure to interpret the unit raises an
+        exception.
+
+    Returns
+    -------
+    :class:`str`
+        If a special exception is detected, the name of the unit
+        is returned.  Otherwise, ``None``.
+
+    Raises
+    ------
+    :exc:`ValueError`
+        If `error` is set and the unit can't be parsed.
+    """
+    acceptable_units = ('maggie', 'maggy', 'mgy',
+                        'electron/Angstrom',
+                        'log(Angstrom)')
+    try:
+        au = Unit(unit, format='fits')
+    except ValueError as e:
+        bad_unit = str(e).split()[0]
+        if any([u in bad_unit for u in acceptable_units]):
+            return bad_unit
+        else:
+            if error:
+                log.critical(str(e))
+                raise
+            else:
+                log.warning(str(e))
+    return None
+
+
+try:
+    from desiutil.annotate import validate_unit
+except ImportError:
+    validate_unit = _validate_unit
+
 
 class DataModelUnit(object):
     """Allow unit-handling code to be shared with several classes.
     """
-    _acceptable_units = ('maggie', 'maggy', 'mgy',
-                         'electron/Angstrom',
-                         'log(Angstrom)')
 
     def check_unit(self, unit, error=False):
-        """Check units for consistency with FITS standard, while allowing
-        some special exceptions.
+        return validate_unit(unit, error=error)
 
-        Parameters
-        ----------
-        unit : :class:`str`
-            The unit to parse.
-        error : :class:`bool`, optional
-            If ``True``, failure to interpret the unit raises an
-            exception.
-
-        Returns
-        -------
-        :class:`str`
-            If a special exception is detected, the name of the unit
-            is returned.  Otherwise, ``None``.
-
-        Raises
-        ------
-        :exc:`ValueError`
-            If `error` is set and the unit can't be parsed.
-        """
-        try:
-            au = Unit(unit, format='fits')
-        except ValueError as e:
-            bad_unit = str(e).split()[0]
-            if any([u in bad_unit for u in self._acceptable_units]):
-                return bad_unit
-            else:
-                if error:
-                    log.critical(str(e))
-                    raise
-                else:
-                    log.warning(str(e))
-        return None
+    check_unit.__doc__ = validate_unit.__doc__

--- a/py/desidatamodel/unit.py
+++ b/py/desidatamodel/unit.py
@@ -7,8 +7,14 @@ desidatamodel.unit
 
 Shared code for dealing with units in files and data models.
 """
+from warnings import warn
 from astropy.units import Unit
-from desiutil.log import log
+
+
+class _FITSUnitWarning(UserWarning):
+    """Warnings related to invalid FITS units.
+    """
+    pass
 
 
 def _validate_unit(unit, error=False):
@@ -45,14 +51,14 @@ def _validate_unit(unit, error=False):
             return bad_unit
         else:
             if error:
-                log.critical(str(e))
                 raise
             else:
-                log.warning(str(e))
+                warn(str(e), FITSUnitWarning)
     return None
 
 
 try:
-    from desiutil.annotate import validate_unit
+    from desiutil.annotate import validate_unit, FITSUnitWarning
 except ImportError:
     validate_unit = _validate_unit
+    FITSUnitWarning = _FITSUnitWarning

--- a/py/desidatamodel/unit.py
+++ b/py/desidatamodel/unit.py
@@ -9,7 +9,7 @@ Shared code for dealing with units in files and data models.
 """
 from astropy.units import Unit
 from desiutil.log import log
-from . import DataModelError
+
 
 def _validate_unit(unit, error=False):
     """Check units for consistency with FITS standard, while allowing

--- a/py/desidatamodel/unit.py
+++ b/py/desidatamodel/unit.py
@@ -56,13 +56,3 @@ try:
     from desiutil.annotate import validate_unit
 except ImportError:
     validate_unit = _validate_unit
-
-
-class DataModelUnit(object):
-    """Allow unit-handling code to be shared with several classes.
-    """
-
-    def check_unit(self, unit, error=False):
-        return validate_unit(unit, error=error)
-
-    check_unit.__doc__ = validate_unit.__doc__

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 astropy
 sphinx-toolbox
 jinja2
-git+https://github.com/desihub/desiutil.git@3.3.0#egg=desiutil
+git+https://github.com/desihub/desiutil.git@3.3.1#egg=desiutil


### PR DESCRIPTION
This PR is a companion to desihub/desiutil#201. It simply imports the unit verification code from desiutil, but if for some reason there is an older version of desiutil in its environment, it falls back on built-in code. Eventually this can be removed.

I want to run a few more operational tests before merging.

* Closes #184.
* Closes #185.