### PR TITLE
Add 5 new columns to data model for Redrock file

### DIFF
--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/tiles/GROUPTYPE/TILEID/GROUPID/redrock-SPECTROGRAPH-TILEID-GROUPID.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/tiles/GROUPTYPE/TILEID/GROUPID/redrock-SPECTROGRAPH-TILEID-GROUPID.rst
@@ -224,13 +224,18 @@ MEAN_DELTA_X               float32 mm           Mean (over exposures) fiber diff
 RMS_DELTA_X                float32 mm           RMS (over exposures) of the fiber difference between measured and requested CS5 X location on focal plane
 MEAN_DELTA_Y               float32 mm           Mean (over exposures) fiber difference requested - actual CS5 Y location on focal plane
 RMS_DELTA_Y                float32 mm           RMS (over exposures) of the fiber difference between measured and requested CS5 Y location on focal plane
+MEAN_PSF_TO_FIBER_SPECFLUX float32              Mean of input exposures fraction of light from point-like source captured by 1.5 arcsec diameter fiber given atmospheric seeing
+MEAN_MJD                   float64 d            Mean MJD across fibers contributing to coadd
+MEAN_FIBER_X               float32 mm           Mean (over exposures) fiber CS5 X location on focal plane
+MEAN_FIBER_Y               float32 mm           Mean (over exposures) fiber CS5 Y location on focal plane
 MEAN_FIBER_RA              float64 deg          Mean (over exposures) RA of actual fiber position
 STD_FIBER_RA               float32 arcsec       Standard deviation (over exposures) of RA of actual fiber position
 MEAN_FIBER_DEC             float64 deg          Mean (over exposures) DEC of actual fiber position
 STD_FIBER_DEC              float32 arcsec       Standard deviation (over exposures) of DEC of actual fiber position
-MEAN_PSF_TO_FIBER_SPECFLUX float32              Mean of input exposures fraction of light from point-like source captured by 1.5 arcsec diameter fiber given atmospheric seeing
-MEAN_FIBER_X               float32 mm           Mean (over exposures) fiber CS5 X location on focal plane
-MEAN_FIBER_Y               float32 mm           Mean (over exposures) fiber CS5 Y location on focal plane
+MIN_MJD                    float64 d            Minimum MJD contributing to fiber coadd
+MAX_MJD                    float64 d            Maximum MJD contributing to fiber coadd
+FIRSTNIGHT                 int32                First night tile was observed (YYYYMMDD)
+LASTNIGHT                  int32                Last night tile was observed (YYYYMMDD)
 ========================== ======= ============ ===============================================================================================================================
 
 .. [1] Optional

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,7 @@ desidatamodel Change Log
 23.6 (unreleased)
 -----------------
 
+* Add 5 coadd-related columns to the fibermap of the Redrock files (PR `#192`_).
 * Add ``DESINAME`` description (PR `#189`_).
 * Update definition of ``ZCAT_NSPEC`` (PR `#187`_).
 * Add note about equivalent width values in ``fuji`` and ``guadalupe`` (PR `#181`_).
@@ -14,6 +15,7 @@ desidatamodel Change Log
 .. _`#181`: https://github.com/desihub/desidatamodel/pull/181
 .. _`#187`: https://github.com/desihub/desidatamodel/pull/187
 .. _`#189`: https://github.com/desihub/desidatamodel/pull/189
+.. _`#192`: https://github.com/desihub/desidatamodel/pull/192
 
 23.1 (2023-06-12)
 -----------------


### PR DESCRIPTION
This PR adds 5 columns (`MEAN_MJD`, `MIN_MJD`, `MAX_MJD`, `FIRSTNIGHT`, `LASTNIGHT`) to the data model for the fibermap part of the Redrock files. These columns arise from coadding fibers across multiple nights.

Related PRs are:

https://github.com/desihub/desispec/pull/2219
https://github.com/desihub/redrock/pull/292