### PR TITLE
expand FIBERSTATUS documentation

### DIFF
--- a/doc/bitmasks.rst
+++ b/doc/bitmasks.rst
@@ -198,12 +198,12 @@ RESERVED31                   31 Reserved sign bit; do not use
 
 **Notes**:
 
-  * Bit 3 (RESTRICTED) is informative and doesn't necessarily mean that the spectrum is bad,
-    i.e. a FIBERSTATUS value of 0 or 8=2**3 is good.
-  * Bit 13 (NEARCHARGETRAP) is fine for most targets but indicates a potential problem for analyses
-    that need consistent purity/completeness, especially for faint targets.
-  * Bit 14 (VARIABLETHRU) have questionable flux calibration, but typically the redshifts are ok.
-  * Bits 13 and 14 were added for DR2/Loa, but were not set at the time of DR1/Iron.
+* Bit 3 (RESTRICTED) is informative and doesn't necessarily mean that the spectrum is bad,
+  i.e. a FIBERSTATUS value of 0 or 8=2**3 is good.
+* Bit 13 (NEARCHARGETRAP) is fine for most targets but indicates a potential problem for analyses
+  that need consistent purity/completeness, especially for faint targets.
+* Bit 14 (VARIABLETHRU) have questionable flux calibration, but typically the redshifts are ok.
+* Bits 13 and 14 were added for DR2/Loa, but were not set at the time of DR1/Iron.
 
 .. _specmask-bitmask:
 


### PR DESCRIPTION
This PR expands the documentation about FIBERSTATUS
  * Adds documentation about bits 13 (NEARCHARGETRAP) and 14 (VARIABLETHRU) added for DR2/Loa but not used in DR1/Iron.
  * Expands discussion about informative vs. fatal bits.
  * Adds entry that is is also used in the redrock FIBERMAP HDU COADD_FIBERSTATUS column.

This PR also adds a summary table at the top, which acts like an annotated table of contents for what bitmasks are available, with links to subsections below.  This makes it easier to navigate to the bitmask of interest without a bunch of scrolling and looking for the one you want.

Note: although this adds documentation for bits that weren't in use for DR1/Iron, the added text isn't incorrect for DR1/Iron either. i.e. we could deploy this as-is without interfering with DR1/Iron.