### PR TITLE
adding missing NUMEXP and NUMTILE column descriptions

### DIFF
--- a/py/desidatamodel/data/column_descriptions.csv
+++ b/py/desidatamodel/data/column_descriptions.csv
@@ -274,7 +274,7 @@ NOBS_R,int16,,Number of images for central pixel in r-band,Number of images for 
 NOBS_Z,int16,,Number of images for central pixel in z-band,Number of images for central pixel in z-band
 NPIXELS,int64,,Number of unmasked pixels used in Redrock fit,Number of unmasked pixels contributing to the Redrock fit
 NTILE,int64,,Number of tiles target was available on,Number of tiles target was available on
-NUMEXP,int16,,Number of exposures in coad,Number of exposures in the coadded spectrum
+NUMEXP,int16,,Number of exposures in coadd,Number of exposures in the coadded spectrum
 NUMOBS,int64,,Nb of spectro observations of this given tile,"Number of spectroscopic observations (on this specific, single tile)"
 NUMOBS_INIT,int64,,Initial number of observations for target,Initial number of observations for target calculated across target selection bitmasks and OBSCONDITIONS
 NUMOBS_MORE,int64,,Number of additional observations needed,Number of additional observations needed

--- a/py/desidatamodel/data/column_descriptions.csv
+++ b/py/desidatamodel/data/column_descriptions.csv
@@ -274,10 +274,12 @@ NOBS_R,int16,,Number of images for central pixel in r-band,Number of images for 
 NOBS_Z,int16,,Number of images for central pixel in z-band,Number of images for central pixel in z-band
 NPIXELS,int64,,Number of unmasked pixels used in Redrock fit,Number of unmasked pixels contributing to the Redrock fit
 NTILE,int64,,Number of tiles target was available on,Number of tiles target was available on
+NUMEXP,int16,,Number of exposures in coad,Number of exposures in the coadded spectrum
 NUMOBS,int64,,Nb of spectro observations of this given tile,"Number of spectroscopic observations (on this specific, single tile)"
 NUMOBS_INIT,int64,,Initial number of observations for target,Initial number of observations for target calculated across target selection bitmasks and OBSCONDITIONS
 NUMOBS_MORE,int64,,Number of additional observations needed,Number of additional observations needed
 NUMTARGET,int16,,Total number of targets covered by positioner,Total number of targets that this positioner covered
+NUMTILE,int16,,Number of tiles in a coadd,Number of unique tiles in a coadded spectrum
 NUM_ITER,int64,,Number of positioner iterations,Number of positioner iterations
 NX,float64,,Estimated mean number density given the redshift and number of overlapping tiles (NTILE),Estimated mean number density given the redshift and number of overlapping tiles (NTILE)
 NZ,float64,h^3 Mpc^-3,Comoving number density of tracer at given z,"The comoving number density of the tracer at the given redshift, assuming complete sample"


### PR DESCRIPTION
Adds missing descriptions for NUMEXP and NUMTILE columns as identified in desihub/desispec#2360.  Other columns mentioned there have been added in the meantime.