### PR TITLE
Update POORPOSITION description

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,9 +17,9 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest]
-                python-version: ['3.10', '3.11']
-                astropy-version: ['<6.1', '<7.0']
-                desiutil-version: ['3.4.3', 'main']
+                python-version: ['3.13']
+                astropy-version: ['<8.0']
+                desiutil-version: ['3.6.1']
 
         steps:
             - name: Checkout code
@@ -48,7 +48,7 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest]
-                python-version: ['3.10']
+                python-version: ['3.13']
 
         steps:
             - name: Checkout code
@@ -82,7 +82,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                python-version: ['3.10']
+                python-version: ['3.13']
 
         steps:
             - name: Checkout code
@@ -111,8 +111,8 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                python-version: ['3.10']
-                desiutil-version: ['3.4.3']
+                python-version: ['3.13']
+                desiutil-version: ['3.6.1']
 
         steps:
             - name: Checkout code
@@ -140,7 +140,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                python-version: ['3.10']
+                python-version: ['3.13']
 
         steps:
             - name: Checkout code

--- a/doc/bitmasks.rst
+++ b/doc/bitmasks.rst
@@ -173,7 +173,7 @@ BROKENFIBER                   2 Broken fiber
 RESTRICTED                    3 INFO: Positioner has restricted reach (but might still be on valid target)
 MISSINGPOSITION               8 Fiber location information is missing
 BADPOSITION                   9 Fiber >100 microns from target location
-POORPOSITION                 10 Fiber >30 microns from target location
+POORPOSITION                 10 Fiber 30-100 microns from target location
 LOWTRANSMISSION              12 Low fiber transmission. Cannot use for sky.
 NEARCHARGETRAP               13 INFO: Fiber trace near charge trap in one of the CCDs
 VARIABLETHRU                 14 INFO: Fiber has throughput variations we cannot model well


### PR DESCRIPTION
Same PR as https://github.com/desihub/desispec/pull/2719:

> This PR corrects the documentation of the "POORPOSITION" bit: the bit also has an upper limit of offset < 100 micron.
See https://github.com/desihub/desispec/blob/main/py/desispec/io/fibermap.py#L949