### PR TITLE
Add uniqpix spectra/ directory tree description

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,9 +17,9 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest]
-                python-version: ['3.10', '3.11']
-                astropy-version: ['<6.1', '<7.0']
-                desiutil-version: ['3.4.3', 'main']
+                python-version: ['3.13']
+                astropy-version: ['<8.0']
+                desiutil-version: ['3.6.1']
 
         steps:
             - name: Checkout code
@@ -48,7 +48,7 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest]
-                python-version: ['3.10']
+                python-version: ['3.13']
 
         steps:
             - name: Checkout code
@@ -82,7 +82,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                python-version: ['3.10']
+                python-version: ['3.13']
 
         steps:
             - name: Checkout code
@@ -111,8 +111,8 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                python-version: ['3.10']
-                desiutil-version: ['3.4.3']
+                python-version: ['3.13']
+                desiutil-version: ['3.6.1']
 
         steps:
             - name: Checkout code
@@ -140,7 +140,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                python-version: ['3.10']
+                python-version: ['3.13']
 
         steps:
             - name: Checkout code

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/index.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/index.rst
@@ -16,8 +16,10 @@ Files in the top-level production directory:
 Subdirectories under a spectroscopic production:
 
 * :doc:`zcatalog/ <zcatalog/index>`: summary redshift catalogs
-* :doc:`healpix/SURVEY/PROGRAM/PIXGROUP/PIXNUM <healpix/SURVEY/PROGRAM/PIXGROUP/PIXNUM/index>`:
-  spectra, classifications, and redshifts coadded across tiles, grouped by survey, program, and healpixel.
+* DR2 and prior: :doc:`healpix/SURVEY/PROGRAM/PIXGROUP/PIXNUM <healpix/SURVEY/PROGRAM/PIXGROUP/PIXNUM/index>`:
+  spectra, classifications, and redshifts coadded across tiles, grouped by survey, program, and fixed-sized nside=64 healpixel.
+* DR3 and after: :doc:`spectra/SURVEY/PROGRAM/PIXGROUP/UNIQPIX <spectra/SURVEY/PROGRAM/PIXGROUP/UNIQPIX/index>`:
+  spectra, classifications, and redshifts coadded across tiles, grouped by survey, program, and adaptively-sized uniqpix.
 * :doc:`tiles/GROUPTYPE/TILEID/GROUPID/index <tiles/GROUPTYPE/TILEID/GROUPID/index>`:
   spectra, classifications, and redshifts coadded per tile.
 * :doc:`calibnight/NIGHT/ <calibnight/NIGHT/index>`: nightly calibrations
@@ -40,6 +42,7 @@ Other subdirectories that represent internal desispec_ pipeline details, but do 
    calibnight/index
    exposures/index
    healpix/index
+   spectra/index
    preproc/index
    tiles/index
    zcatalog/index

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/spectra/SURVEY/PROGRAM/PIXGROUP/UNIQPIX/index.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/spectra/SURVEY/PROGRAM/PIXGROUP/UNIQPIX/index.rst
@@ -13,4 +13,4 @@ Default $DESI_ROOT/spectro/redux/SPECPROD/spectra/SURVEY/PROGRAM/PIXGROUP/UNIQPI
 
 The available files and formats are the same as those in the
 :doc:`healpix directory tree </DESI_SPECTRO_REDUX/SPECPROD/healpix/SURVEY/PROGRAM/PIXGROUP/PIXNUM/index>`
-with the addition of a ``UNIQPIX`` header heyword.
+with the addition of a ``UNIQPIX`` header keyword.

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/spectra/SURVEY/PROGRAM/PIXGROUP/UNIQPIX/index.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/spectra/SURVEY/PROGRAM/PIXGROUP/UNIQPIX/index.rst
@@ -2,12 +2,14 @@
 UNIQPIX
 =======
 
+Note: new in Matterhorn / Nevis / DR3; not yet public.
+
 Default $DESI_ROOT/spectro/redux/SPECPROD/spectra/SURVEY/PROGRAM/PIXGROUP/UNIQPIX
 
   * SURVEY = sv1, sv3, main, ...
   * PROGRAM = dark,bright,backup,other
-  * UNIQPIX = HEALPIX + 4*NSIDE^2 adaptively sided pixel
-  * PIXGROUP = int(PIXNUM/100)
+  * UNIQPIX = HEALPIX + 4*NSIDE^2 adaptively sized pixel
+  * PIXGROUP = int(UNIQPIX/100)
 
 The available files and formats are the same as those in the
 :doc:`healpix directory tree </DESI_SPECTRO_REDUX/SPECPROD/healpix/SURVEY/PROGRAM/PIXGROUP/PIXNUM/index>`

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/spectra/SURVEY/PROGRAM/PIXGROUP/UNIQPIX/index.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/spectra/SURVEY/PROGRAM/PIXGROUP/UNIQPIX/index.rst
@@ -1,0 +1,14 @@
+=======
+UNIQPIX
+=======
+
+Default $DESI_ROOT/spectro/redux/SPECPROD/spectra/SURVEY/PROGRAM/PIXGROUP/UNIQPIX
+
+  * SURVEY = sv1, sv3, main, ...
+  * PROGRAM = dark,bright,backup,other
+  * UNIQPIX = HEALPIX + 4*NSIDE^2 adaptively sided pixel
+  * PIXGROUP = int(PIXNUM/100)
+
+The available files and formats are the same as those in the
+:doc:`healpix directory tree </DESI_SPECTRO_REDUX/SPECPROD/healpix/SURVEY/PROGRAM/PIXGROUP/PIXNUM/index>`
+with the addition of a ``UNIQPIX`` header heyword.

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/spectra/SURVEY/PROGRAM/PIXGROUP/index.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/spectra/SURVEY/PROGRAM/PIXGROUP/index.rst
@@ -1,0 +1,11 @@
+========
+PIXGROUP
+========
+
+Pixels are grouped by subdirectories of ``PIXGROUP = int(UNIQPIX/100)`` to avoid having
+tens of thousands of directories at the same level.
+
+.. toctree::
+   :maxdepth: 1
+
+   UNIQPIX/index

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/spectra/SURVEY/PROGRAM/hpix2upix-SURVEY-PROGRAM.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/spectra/SURVEY/PROGRAM/hpix2upix-SURVEY-PROGRAM.rst
@@ -2,7 +2,7 @@
 hpix2upix
 =========
 
-:Summary: This file contains a mapping of large nside healpix to adaptively size uniqpix.
+:Summary: This file contains a mapping of large nside healpix to adaptively sized uniqpix.
 :Naming Convention: ``hpix2upix-SURVEY-PROGRAM.fits``,
     where SURVEY is main, sv1, sv2, sv3, special, or cmx;
     and PROGRAM is bright, dark, backup, or other.

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/spectra/SURVEY/PROGRAM/hpix2upix-SURVEY-PROGRAM.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/spectra/SURVEY/PROGRAM/hpix2upix-SURVEY-PROGRAM.rst
@@ -1,0 +1,105 @@
+=========
+hpix2upix
+=========
+
+:Summary: This file contains a mapping of large nside healpix to adaptively size uniqpix.
+:Naming Convention: ``hpix2upix-SURVEY-PROGRAM.fits``,
+    where SURVEY is main, sv1, sv2, sv3, special, or cmx;
+    and PROGRAM is bright, dark, backup, or other.
+:Regex: ``hpix2upix-(cmx|main|special|sv1|sv2|sv3)-(backup|bright|dark|other).fits``
+:File Type: FITS, 9 MB
+
+Contents
+========
+
+====== ============= ===== ===================
+Number EXTNAME       Type  Contents
+====== ============= ===== ===================
+HDU0_  HPIX2UPIX     IMAGE Mapping from healpix to uniqpix
+HDU1_  HPIX_NTARGETS IMAGE Number of unique targets in each uniqpix
+====== ============= ===== ===================
+
+
+FITS Header Units
+=================
+
+HDU0
+----
+
+EXTNAME = HPIX2UPIX
+
+Mapping from healpix to uniqpix at the NSIDE given in the header.
+
+Required Header Keywords
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. collapse:: Required Header Keywords Table
+
+    .. rst-class:: keywords
+
+    ======== ============= ==== =====================
+    KEY      Example Value Type Comment
+    ======== ============= ==== =====================
+    NAXIS1   786432        int  Size of array: Number of healpixels at this NSIDE
+    NSIDE    256           int  The nside used for the healpix calculation.
+    HPXNSIDE 256           int  Same as NSIDE
+    HPXNEST  T             bool Whether the healpix is in nested ordering (T) or ring ordering (F).
+    SURVEY   main          str  DESI survey name: main, sv1, sv2, sv3, special, or cmx
+    PROGRAM  dark          str  DESI program name: bright, dark, backup, or other
+    SPECPROD matterhorn    str  DESI spectro production name, e.g. matterhorn, nevis
+    ======== ============= ==== =====================
+
+Data: FITS image [int64, 786432]
+
+This array is indexed by the healpixel number, and the value is the corresponding uniqpix number.
+The healpix number is calculated using the NSIDE header keyword, which is the largest NSIDE used
+by any uniqpix in this production.  If a healpix is not covered by any uniqpix in this production,
+then the value is -1.
+
+HDU1
+----
+
+EXTNAME = HPIX_NTARGETS
+
+The number of targets per healpix.
+
+Required Header Keywords
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. collapse:: Required Header Keywords Table
+
+    .. rst-class:: keywords
+
+    ======== ============= ==== =====================
+    KEY      Example Value Type Comment
+    ======== ============= ==== =====================
+    NAXIS1   786432        int  Size of array: Number of healpixels at this NSIDE
+    NSIDE    256           int  The nside used for the healpix calculation.
+    HPXNSIDE 256           int  Same as NSIDE
+    HPXNEST  T             bool Whether the healpix is in nested ordering (T) or ring ordering (F).
+    SURVEY   main          str  DESI survey name: main, sv1, sv2, sv3, special, or cmx
+    PROGRAM  dark          str  DESI program name: bright, dark, backup, or other
+    SPECPROD matterhorn    str  DESI spectro production name, e.g. matterhorn, nevis
+    ======== ============= ==== =====================
+
+Data: FITS image [int32, 786432]
+
+Even if a healpix is covered by a uniqpix, it may not contain any targets.  This array gives the number of targets in each healpix, which can be used to quickly determine if a healpix contains any targets without having to read the corresponding uniqpix.
+
+Notes and Examples
+==================
+
+Example usage::
+
+    import healpy
+    import fitsio
+
+    with fitsio.FITS('spectra/main/dark/hpix2upix-main-dark.fits') as fx:
+        header = fx['HPIX2UPIX'].read_header()
+        hpix2upix = fx['HPIX2UPIX'].read()
+        hpix_ntargets = fx['HPIX_NTARGETS'].read()
+
+    nsidemax = header['NSIDE']
+    hpix = healpy.ang2pix(nsidemax, ra, dec, lonlat=True, nest=True)
+    upix = hpix2upix[hpix]
+    ntargets = hpix_ntargets[hpix]

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/spectra/SURVEY/PROGRAM/index.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/spectra/SURVEY/PROGRAM/index.rst
@@ -1,0 +1,22 @@
+=======
+PROGRAM
+=======
+
+The ``PROGRAM`` is related to tile design.  The current allowed values are
+``backup``, ``bright``, ``dark`` and ``other``.
+
+Caveats
+-------
+
+1. The value of ``PROGRAM`` actually comes from the ``FAPRGRM`` in fiberassign
+   files.
+2. The value of ``PROGRAM`` *does not* reflect the value of ``PROGRAM`` as
+   obtained from the corresponding header keyword in raw data files.
+3. For ``SURVEY = sv1``, the values of ``FAPRGRM`` had not stabilized, so
+   for ``sv1``, the ``PROGRAM`` is assigned *post facto*.
+
+
+.. toctree::
+   :maxdepth: 1
+
+   PIXGROUP/index

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/spectra/SURVEY/PROGRAM/index.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/spectra/SURVEY/PROGRAM/index.rst
@@ -2,11 +2,17 @@
 PROGRAM
 =======
 
-The ``PROGRAM`` is related to tile design.  The current allowed values are
-``backup``, ``bright``, ``dark`` and ``other``.
+This directory contains summary files for the uniqpix covered by this ``SURVEY`` and ``PROGRAM``,
+and subdirectories grouping those uniqpix.  The ``PROGRAM`` is related to tile design.  The current allowed values are
+``dark``, ``bright``, ``backup`` and ``other``.
 
-Caveats
--------
+The summary files are:
+
+  * :doc:`hpix2upix-SURVEY-PROGRAM.fits <hpix2upix-SURVEY-PROGRAM>`: a mapping from healpix to uniqpix for this ``SURVEY`` and ``PROGRAM``.
+  * :doc:`uniqpix-SURVEY-PROGRAM.fits <uniqpix-SURVEY-PROGRAM>`: a table of uniqpix covered by this ``SURVEY`` and ``PROGRAM`` with the number of unique targets and number of input uncoadded spectra.
+
+Notes
+-----
 
 1. The value of ``PROGRAM`` actually comes from the ``FAPRGRM`` in fiberassign
    files.
@@ -20,3 +26,5 @@ Caveats
    :maxdepth: 1
 
    PIXGROUP/index
+   hpix2upix-SURVEY-PROGRAM
+   uniqpix-SURVEY-PROGRAM

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/spectra/SURVEY/PROGRAM/uniqpix-SURVEY-PROGRAM.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/spectra/SURVEY/PROGRAM/uniqpix-SURVEY-PROGRAM.rst
@@ -101,7 +101,7 @@ Output for the matterhorn production::
     spectra/special/dark/6996/699670/coadd-special-dark-699670.fits at nside=256 has 2045 targets (38,985.2/deg^2)
     spectra/special/dark/6996/699671/coadd-special-dark-699671.fits at nside=256 has 1261 targets (24,039.3/deg^2)
 
-Note that the vastly different target densities get covered by different nside pixels so
-that each file has at most few thousand targets.
+Note that the vastly different target densities are covered by different nside pixels so
+that each file has at most a few thousand targets.
 
 

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/spectra/SURVEY/PROGRAM/uniqpix-SURVEY-PROGRAM.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/spectra/SURVEY/PROGRAM/uniqpix-SURVEY-PROGRAM.rst
@@ -1,0 +1,107 @@
+=======
+uniqpix
+=======
+
+:Summary: This file contains a summary of which uniqpix are covered by this survey and program.
+:Naming Convention: ``uniqpix-SURVEY-PROGRAM.fits``,
+    where SURVEY is main, sv1, sv2, sv3, special, or cmx;
+    and PROGRAM is bright, dark, backup, or other.
+:Regex: ``uniqpix-(cmx|main|special|sv1|sv2|sv3)-(backup|bright|dark|other).fits``
+:File Type: FITS, 430 KB
+
+Contents
+========
+
+====== ======= ======== ===================
+Number EXTNAME Type     Contents
+====== ======= ======== ===================
+HDU0_          IMAGE    Blank
+HDU1_  UNIQPIX BINTABLE Table with UNIQPIX, NTARGETS, NSPECTRA
+====== ======= ======== ===================
+
+
+FITS Header Units
+=================
+
+HDU0
+----
+
+This HDU has no non-standard required keywords.
+
+Empty HDU.
+
+HDU1
+----
+
+EXTNAME = UNIQPIX
+
+Table giving the number of targets and spectra for each uniqpix in this survey and program.
+
+Required Header Keywords
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. collapse:: Required Header Keywords Table
+
+    .. rst-class:: keywords
+
+    ======== ============= ==== =====================
+    KEY      Example Value Type Comment
+    ======== ============= ==== =====================
+    NAXIS1   24            int  Size of each table row
+    NAXIS2   17929         int  Number of table rows = number of uniqpix
+    SURVEY   main          str  DESI survey name, e.g. main, sv1, sv2, sv3, special, or cmx
+    PROGRAM  dark          str  DESI program name, e.g. bright, dark, backup, or other
+    SPECPROD matterhorn    str  DESI spectro pipeline product name, e.g. matterhorn or nevis
+    ======== ============= ==== =====================
+
+Required Data Table Columns
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. rst-class:: columns
+
+======== ===== ===== ===========
+Name     Type  Units Description
+======== ===== ===== ===========
+UNIQPIX  int64       Unique pixel identifier = healpix + 4*nside^2
+NTARGETS int64       Number of unique TARGETIDs in this uniqpix for this survey and program
+NSPECTRA int64       Number of input uncoadded spectra in this uniqpix for this survey and program
+======== ===== ===== ===========
+
+
+Notes and Examples
+==================
+
+Example usage::
+
+    from astropy.table import Table
+    import numpy as np
+    import healpy
+
+    survey = 'special'
+    program = 'dark'
+    upix_table = Table.read(f'spectra/{survey}/{program}/uniqpix-{survey}-{program}.fits')
+    for upix, ntargets in upix_table['UNIQPIX', 'NTARGETS']:
+        nside = 2**int(np.log2(upix//4)/2)
+        hpix = upix - 4 * nside**2
+        area = healpy.nside2pixarea(nside, degrees=True)
+        density = ntargets / area
+
+        pixgroup = upix//100
+        coaddfile = f'spectra/special/dark/{pixgroup}/{upix}/coadd-special-dark-{upix}.fits'
+
+        print(f'{coaddfile} at {nside=} has {ntargets} targets ({density:,.1f}/deg^2)')
+
+Output for the matterhorn production::
+
+    spectra/special/dark/0/5/coadd-special-dark-5.fits at nside=1 has 353 targets (0.1/deg^2)
+    spectra/special/dark/0/7/coadd-special-dark-7.fits at nside=1 has 3965 targets (1.2/deg^2)
+    spectra/special/dark/0/9/coadd-special-dark-9.fits at nside=1 has 1147 targets (0.3/deg^2)
+    ...
+    spectra/special/dark/6996/699669/coadd-special-dark-699669.fits at nside=256 has 2119 targets (40,395.9/deg^2)
+    spectra/special/dark/6996/699670/coadd-special-dark-699670.fits at nside=256 has 2045 targets (38,985.2/deg^2)
+    spectra/special/dark/6996/699671/coadd-special-dark-699671.fits at nside=256 has 1261 targets (24,039.3/deg^2)
+
+Note that the vastly different target densities get covered by different nside pixels so
+that each file has at most few thousand targets.
+
+

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/spectra/SURVEY/index.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/spectra/SURVEY/index.rst
@@ -1,0 +1,11 @@
+======
+SURVEY
+======
+
+The ``SURVEY`` is the phase of the overall DESI project the spectra were
+observed in.  The current values are ``sv1``, ``sv2``, ``sv3``, ``main``.
+
+.. toctree::
+   :maxdepth: 1
+
+   PROGRAM/index

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/spectra/index.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/spectra/index.rst
@@ -4,7 +4,7 @@ spectra
 
 Starting with the Matterhorn production (test run for DR3), 
 spectra are grouped by ``spectra/SURVEY/PROGRAM/PIXGROUP/UNIQPIX``, where
-``UNIXPIX = HEALPIX + 4*NSIDE^2`` are adaptively-sided healpixels to balance
+``UNIQPIX = HEALPIX + 4*NSIDE^2`` is an adaptively sized healpixel identifier used to balance
 the number of targets per file.
 
 For current public releases, see the :doc:`healpix <../healpix/index>` directory tree

--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/spectra/index.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/spectra/index.rst
@@ -1,0 +1,16 @@
+=======
+spectra
+=======
+
+Starting with the Matterhorn production (test run for DR3), 
+spectra are grouped by ``spectra/SURVEY/PROGRAM/PIXGROUP/UNIQPIX``, where
+``UNIXPIX = HEALPIX + 4*NSIDE^2`` are adaptively-sided healpixels to balance
+the number of targets per file.
+
+For current public releases, see the :doc:`healpix <../healpix/index>` directory tree
+which uses fixed-size nside=64 healpixels.
+
+.. toctree::
+   :maxdepth: 1
+
+   SURVEY/index


### PR DESCRIPTION
This PR adds the description for the spectra/ directory tree with uniqpix-based spectral grouping, starting with matterhorn.  A rendering of this branch is available at https://data.desi.lbl.gov/desi/users/sjbailey/git/desidatamodel/doc/_build/html/DESI_SPECTRO_REDUX/SPECPROD/spectra/SURVEY/PROGRAM/PIXGROUP/UNIQPIX/index.html (and subdirs).