### PR TITLE
Fix MEAN_FIBER_Y description in v1 ztile zcatalog

### DIFF
--- a/doc/DESI_SPECTRO_REDUX/SPECPROD/zcatalog/v1/ztile-SURVEY-PROGRAM-GROUPTYPE.rst
+++ b/doc/DESI_SPECTRO_REDUX/SPECPROD/zcatalog/v1/ztile-SURVEY-PROGRAM-GROUPTYPE.rst
@@ -222,7 +222,7 @@ MIN_MJD                    float64     d            Minimum value of the Modifie
 MAX_MJD                    float64     d            Maximum value of the Modified Julian Date (when the shutter was open for the last exposure used in the coadded spectrum)
 MEAN_MJD                   float64     d            Mean value of the Modified Julian Date (when the shutter was open for exposures used in the coadded spectrum)
 MEAN_FIBER_X               float32     mm           Mean (over exposures) fiber CS5 X location on focal plane
-MEAN_FIBER_Y               float32     mm           Mean (over exposures) fiber CS5 X location on focal plane
+MEAN_FIBER_Y               float32     mm           Mean (over exposures) fiber CS5 Y location on focal plane
 TSNR2_GPBDARK_B            float32                  template (S/N)^2 for dark targets in guider pass band on B
 TSNR2_ELG_B                float32                  ELG B template (S/N)^2
 TSNR2_GPBBRIGHT_B          float32                  template (S/N)^2 for bright targets in guider pass band on B


### PR DESCRIPTION
## Summary

Fixes a copy-paste typo in the `MEAN_FIBER_Y` column description in `doc/DESI_SPECTRO_REDUX/SPECPROD/zcatalog/v1/ztile-SURVEY-PROGRAM-GROUPTYPE.rst`.

The description read "Mean (over exposures) fiber CS5 **X** location on focal plane" (duplicated from `MEAN_FIBER_X`); it now correctly reads "CS5 **Y** location".

## Notes

The v2 zcatalog docs already had the correct "Y location" wording, so this only affects the v1 model file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)